### PR TITLE
Hotfix decode issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import sbtcrossproject.{CrossType, crossProject}
 
 val V = new {
-  val cats              = "1.1.0"
   val fs2               = "0.10.5"
   val `kind-projector`  = "0.9.7"
   val kittens           = "1.1.0"

--- a/core/src/main/scala/laserdisc/package.scala
+++ b/core/src/main/scala/laserdisc/package.scala
@@ -14,6 +14,8 @@ import shapeless.nat._
 
 package object laserdisc {
 
+  type |[A, B] = Either[A, B]
+
   //type forwarders
   final type Protocol   = protocol.Protocol
   final type Read[A, B] = protocol.Read[A, B]

--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -424,10 +424,10 @@ sealed trait RESPFunctions { this: RESPCodecs =>
       res => Right(res)
     )
 
-  private sealed trait Sized
-  private final case object Bulk extends Sized
-  private final case object Multi extends Sized
-  private final case object No extends Sized
+  private sealed trait SizedContentType
+  private final case object Bulk extends SizedContentType
+  private final case object Multi extends SizedContentType
+  private final case object No extends SizedContentType
 }
 
 object BitVectorDecoding {

--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -389,7 +389,7 @@ sealed trait RESPCodecs { this: RESPBuilders =>
 
 sealed trait RESPFunctions { this: RESPCodecs =>
 
-  import aaa._
+  import BitVectorDecoding._
 
   final def stateOf: BitVector => String | BitVectorState =
     bits => bits.consume(BitsInByte) {
@@ -430,9 +430,7 @@ sealed trait RESPFunctions { this: RESPCodecs =>
   private final case object No extends Sized
 }
 
-object RESP extends RESPBuilders with RESPCodecs with RESPFunctions
-
-object aaa {
+object BitVectorDecoding {
 
   sealed trait BitVectorState extends Product with Serializable
   final case class MissingBits(stillToReceive: Long) extends BitVectorState
@@ -440,3 +438,5 @@ object aaa {
   final case object IncompleteVector extends BitVectorState
   final case object CompleteVector extends BitVectorState
 }
+
+object RESP extends RESPBuilders with RESPCodecs with RESPFunctions

--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -3,6 +3,7 @@ package laserdisc.protocol
 import java.{lang => j}
 import java.nio.charset.StandardCharsets.UTF_8
 
+import laserdisc.|
 import scodec.Decoder.decodeCollect
 import scodec.Encoder.encodeSeq
 import scodec.bits.{BitVector, _}
@@ -219,7 +220,7 @@ object NonNilArray {
   final def unapply(nonEmptyArray: NonNilArray): Option[Vector[RESP]] = Some(nonEmptyArray.elements)
 }
 
-trait RESPBuilders {
+sealed trait RESPBuilders {
   final def str(value: String): SimpleString = new SimpleString(value)
 
   final def err(message: String): Error = new Error(message)
@@ -234,17 +235,18 @@ trait RESPBuilders {
   final def arr(xs: Seq[RESP]): NonNilArray          = new NonNilArray(xs.toVector)
 }
 
-trait RESPCodecs { this: RESPBuilders =>
-  private final val utf8       = new LenientStringCodec(UTF_8)
-  private final val BitsInByte = 8L
-  private final val plus :: minus :: colon :: dollar :: star :: crlf :: minusOne :: zero :: Nil =
+sealed trait RESPCodecs { this: RESPBuilders =>
+
+  protected final val utf8       = new LenientStringCodec(UTF_8)
+  protected final val BitsInByte = 8L
+  protected final val plus :: minus :: colon :: dollar :: star :: crlf :: minusOne :: zero :: Nil =
     (hex"2b" :: hex"2d" :: hex"3a" :: hex"24" :: hex"2a" :: hex"0d0a" :: hex"2d31" :: hex"30" :: Nil)
       .map(_.bits)
   private final val crlfSize      = crlf.size
   private final val crlfBytes     = crlf.bytes
   private final val crlfBytesSize = crlfBytes.size
 
-  private final def crlfTerminatedStringOfSize(size: Long) =
+  private final def crlfTerminatedStringOfSize(size: Long): Codec[String] =
     filtered(
       utf8,
       new Codec[BitVector] {
@@ -257,9 +259,11 @@ trait RESPCodecs { this: RESPBuilders =>
           }
       }
     ).withToString("crlf-terminated string")
+
   private final val crlfTerminatedString = crlfTerminatedStringOfSize(0)
-  private final val longAsCRLFTerminatedString = crlfTerminatedString
-    .narrow[Long](
+
+  protected final val longAsCRLFTerminatedString =
+    crlfTerminatedString.narrow[Long](
       s =>
         try Attempt.successful(j.Long.parseLong(s))
         catch { case _: NumberFormatException => Attempt.failure(Err(s"Expected long but found $s")) },
@@ -269,42 +273,58 @@ trait RESPCodecs { this: RESPBuilders =>
 
   private final val simpleStringCodec: Codec[SimpleString] =
     crlfTerminatedString.xmap[SimpleString](str, _.value).withToString("simple-string")
+
   private final val errorCodec: Codec[Error] =
     crlfTerminatedString.xmap[Error](err, _.message).withToString("error")
+
   private final val integerCodec: Codec[Integer] =
     longAsCRLFTerminatedString.xmap[Integer](int, _.value).withToString("integer")
+
   private final val bulkStringCodec: Codec[BulkString] = new Codec[BulkString] {
+
     private final val nullBulkStringBits = minusOne ++ crlf
+
     private final val decoder = longAsCRLFTerminatedString.flatMap {
       case -1                => Decoder.point(NullBulkString)
       case size if size >= 0 => fixedSizeBytes(size + crlfBytesSize, crlfTerminatedStringOfSize(size)).map(bulk)
       case negSize           => Decoder.liftAttempt(Attempt.failure(failDec(negSize)))
     }
+
     private final def failDec(negSize: Long) =
       Err.General(s"failed to decode bulk-string of size $negSize", List("size"))
+
     private final def failEnc(bulkString: BulkString, err: Err) =
       Err.General(s"failed to encode size of [$bulkString]: ${err.messageWithContext}", List("size"))
 
     override final def sizeBound: SizeBound = SizeBound.unknown
-    override final def encode(bulkString: BulkString): Attempt[BitVector] = bulkString match {
-      case NullBulkString => Attempt.successful(nullBulkStringBits)
-      case NonNullBulkString(s) =>
-        crlfTerminatedString.encode(s).flatMap { bits =>
-          longAsCRLFTerminatedString
-            .encode(bits.size / BitsInByte - crlfBytesSize)
-            .mapErr(failEnc(bulkString, _))
-            .map(_ ++ bits)
-        }
-    }
+
+    override final def encode(bulkString: BulkString): Attempt[BitVector] =
+      bulkString match {
+        case NullBulkString => Attempt.successful(nullBulkStringBits)
+        case NonNullBulkString(s) =>
+          crlfTerminatedString.encode(s).flatMap { bits =>
+            longAsCRLFTerminatedString
+              .encode(bits.size / BitsInByte - crlfBytesSize)
+              .mapErr(failEnc(bulkString, _))
+              .map(_ ++ bits)
+          }
+      }
+
     override final def decode(buffer: BitVector): Attempt[DecodeResult[BulkString]] = decoder.decode(buffer)
+
     override final def toString: String                                             = "bulk-string"
   }
+
   private final val arrayCodec: Codec[Array] = new Codec[Array] {
+
     private final val nilArrayBits   = minusOne ++ crlf
+
     private final val emptyArrayBits = zero ++ crlf
+
     private final def checkSize(v: Vector[RESP], expectedSize: Long) =
       if (v.size == expectedSize) Attempt.successful(v)
       else Attempt.failure(Err(s"Insufficient number of elements: decoded ${v.size} instead of $expectedSize"))
+
     private final val decoder = longAsCRLFTerminatedString.flatMap {
       case -1 => Decoder.point(NilArray)
       case 0  => Decoder.point(arr(Seq.empty))
@@ -314,12 +334,15 @@ trait RESPCodecs { this: RESPBuilders =>
           .map(arr(_))
       case negSize => Decoder.liftAttempt(Attempt.failure(failDec(negSize)))
     }
+
     private final def failDec(negSize: Long) =
       Err.General(s"failed to decode array of size $negSize", List("size"))
+
     private final def failEnc(array: Array, err: Err) =
       Err.General(s"failed to encode size of [$array]: ${err.messageWithContext}", List("size"))
 
     override final def sizeBound: SizeBound = SizeBound.unknown
+
     override final def encode(array: Array): Attempt[BitVector] = array match {
       case NilArray                    => Attempt.successful(nilArrayBits)
       case NonNilArray(v) if v.isEmpty => Attempt.successful(emptyArrayBits)
@@ -334,14 +357,17 @@ trait RESPCodecs { this: RESPBuilders =>
   }
 
   implicit final val respCodec: Codec[RESP] = new Codec[RESP] {
+
     override final def sizeBound: SizeBound = SizeBound.unknown
+
     override final def encode(value: RESP): Attempt[BitVector] = value match {
-      case simpleString: SimpleString => simpleStringCodec.encode(simpleString).map(plus ++ _)
-      case error: Error               => errorCodec.encode(error).map(minus ++ _)
-      case integer: Integer           => integerCodec.encode(integer).map(colon ++ _)
-      case bulkString: BulkString     => bulkStringCodec.encode(bulkString).map(dollar ++ _)
-      case array: Array               => arrayCodec.encode(array).map(star ++ _)
+      case simpleString : SimpleString  => simpleStringCodec.encode(simpleString).map(plus ++ _)
+      case error        : Error         => errorCodec.encode(error).map(minus ++ _)
+      case integer      : Integer       => integerCodec.encode(integer).map(colon ++ _)
+      case bulkString   : BulkString    => bulkStringCodec.encode(bulkString).map(dollar ++ _)
+      case array        : Array         => arrayCodec.encode(array).map(star ++ _)
     }
+
     override final def decode(bits: BitVector): Attempt[DecodeResult[RESP]] =
       bits
         .consume(BitsInByte) {
@@ -350,13 +376,55 @@ trait RESPCodecs { this: RESPBuilders =>
           case `colon`  => Right(integerCodec)
           case `dollar` => Right(bulkStringCodec)
           case `star`   => Right(arrayCodec)
-          case other    => Left(s"unidentified RESP type ${other.toHex}")
+          case other    => Left(s"unidentified RESP type (Hex: ${other.toHex})")
         }
         .fold(
-          error => Attempt.failure(Err(error)), { case (remainder, codec) => codec.decode(remainder) }
+          error => Attempt.failure(Err(error)),
+          { case (remainder, codec) => codec.decode(remainder) }
         )
+
     override final def toString: String = "RESP"
   }
 }
 
-object RESP extends RESPBuilders with RESPCodecs
+sealed trait RESPFunctions { this: RESPCodecs =>
+
+  final def stillToReceive: BitVector => String | Long =
+    bits => bits.consume(BitsInByte) {
+      case `plus`
+           | `minus`
+           | `colon` => Right(No)
+      case `dollar`  => Right(Bulk)
+      case `star`    => Right(Multi)
+      case other     => Left(s"unidentified RESP type (Hex: ${other.toHex})")
+    }
+    .flatMap {
+      case (remainder, Bulk) =>
+        withSizeIn(remainder) {
+          ds =>
+            if (ds.value >= 0 && ds.remainder.size == (crlf.size + (ds.value * BitsInByte))) 0L // Complete: expected size
+            else if (ds.value == -1) 0L // Complete: empty bulk
+            else (crlf.size + (ds.value * BitsInByte)) - ds.remainder.size
+        }
+
+      case (remainder, Multi) =>
+        withSizeIn(remainder) {
+          ds => 0L
+        }
+
+      case (_, No)    => Right(0L)
+    }
+
+  private final def withSizeIn[A](bits: BitVector)(f: DecodeResult[Long] => A): String | A =
+    (longAsCRLFTerminatedString.decode(bits) map f).fold (
+      err => Left(err.message),
+      res => Right(res)
+    )
+
+  private sealed trait Sized
+  private case object Bulk extends Sized
+  private case object Multi extends Sized
+  private case object No extends Sized
+}
+
+object RESP extends RESPBuilders with RESPCodecs with RESPFunctions

--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -1,9 +1,9 @@
-package laserdisc.protocol
+package laserdisc
+package protocol
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.{lang => j}
 
-import laserdisc.|
 import scodec.Decoder.decodeCollect
 import scodec.Encoder.encodeSeq
 import scodec.bits.{BitVector, _}

--- a/core/src/main/scala/laserdisc/protocol/StringP.scala
+++ b/core/src/main/scala/laserdisc/protocol/StringP.scala
@@ -127,7 +127,8 @@ trait StringP {
 
   final def get[A](key: Key)(
       implicit ev: NonNullBulkString ==> A
-  ): Protocol.Aux[Option[A]] = Protocol("GET", key).asC[NullBulkString :+: NonNullBulkString :+: CNil, Option[A]]
+  ): Protocol.Aux[Option[A]] =
+    Protocol("GET", key).asC[NullBulkString :+: NonNullBulkString :+: CNil, Option[A]]
 
   final def getbit(key: Key, offset: PosLong): Protocol.Aux[Bit] =
     Protocol("GETBIT", key :: offset :: HNil).as[Integer, Bit]

--- a/core/src/test/scala/laserdisc/protocol/RESPCodecsSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPCodecsSpec.scala
@@ -90,7 +90,7 @@ final class RESPCodecsSpec extends WordSpec with MustMatchers with PropertyCheck
 
     "handling unknown protocol type" must {
       "fail with correct error message" in forAll { invalidDiscriminator: InvalidDiscriminator =>
-        s"$invalidDiscriminator".RESP.left.value.messageWithContext mustBe s"unidentified RESP type ${invalidDiscriminator.toHex}"
+        s"$invalidDiscriminator".RESP.left.value.messageWithContext mustBe s"unidentified RESP type (Hex: ${invalidDiscriminator.toHex})"
       }
     }
 

--- a/fs2/src/main/scala/laserdisc/fs2/Frame.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/Frame.scala
@@ -3,7 +3,7 @@ package laserdisc.fs2
 import cats.syntax.either._
 import fs2.Chunk
 import laserdisc.protocol.RESP
-import laserdisc.protocol.aaa._
+import laserdisc.protocol.BitVectorDecoding._
 import laserdisc.|
 import scodec.bits.BitVector
 

--- a/fs2/src/main/scala/laserdisc/fs2/Frame.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/Frame.scala
@@ -1,0 +1,40 @@
+package laserdisc.fs2
+
+import cats.syntax.either._
+import fs2.Chunk
+import laserdisc.protocol.RESP
+import laserdisc.protocol.aaa._
+import laserdisc.|
+import scodec.bits.BitVector
+
+sealed trait Frame extends Product with Serializable {
+
+  def append(chunk: Chunk[Byte]): Exception | NonEmptyFrame =
+    nextFrame(BitVector.view(chunk.toByteBuffer))
+
+  protected final def nextFrame(bits: BitVector): Exception | NonEmptyFrame =
+    RESP.stateOf(bits) map {
+      case MissingBits(n)        => Incomplete(bits, n)
+      case CompleteAndDecoded(r) => Decoded(r.value)
+      case IncompleteVector      => Incomplete(bits, 0L)
+      case CompleteVector        => Complete(bits)
+    } leftMap (new Exception(_))
+}
+
+sealed trait NonEmptyFrame extends Product with Serializable
+
+case object Empty extends Frame
+
+final case class Complete(full: BitVector) extends Frame with NonEmptyFrame
+final case class Decoded(resp: RESP) extends Frame with NonEmptyFrame
+final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends Frame with NonEmptyFrame {
+
+  override def append(chunk: Chunk[Byte]): Exception | NonEmptyFrame = {
+
+    val newBits = BitVector.view(chunk.toByteBuffer)
+
+    //  Saves some size inspections
+    if (bitsToComplete > 0 && bitsToComplete == newBits.size) Right(Complete(partial ++ newBits))
+    else nextFrame(partial ++ newBits)
+  }
+}

--- a/fs2/src/main/scala/laserdisc/fs2/Frame.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/Frame.scala
@@ -2,8 +2,8 @@ package laserdisc.fs2
 
 import cats.syntax.either._
 import fs2.Chunk
-import laserdisc.protocol.RESP
 import laserdisc.protocol.BitVectorDecoding._
+import laserdisc.protocol.RESP
 import laserdisc.|
 import scodec.bits.BitVector
 
@@ -22,9 +22,7 @@ sealed trait Frame extends Product with Serializable {
 }
 
 sealed trait NonEmptyFrame extends Product with Serializable
-
 case object Empty extends Frame
-
 final case class Complete(full: BitVector) extends Frame with NonEmptyFrame
 final case class Decoded(resp: RESP) extends Frame with NonEmptyFrame
 final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends Frame with NonEmptyFrame {

--- a/fs2/src/main/scala/laserdisc/fs2/Frame.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/Frame.scala
@@ -1,10 +1,10 @@
-package laserdisc.fs2
+package laserdisc
+package fs2
 
+import _root_.fs2.Chunk
 import cats.syntax.either._
-import fs2.Chunk
 import laserdisc.protocol.BitVectorDecoding._
 import laserdisc.protocol.RESP
-import laserdisc.|
 import scodec.bits.BitVector
 
 sealed trait Frame extends Product with Serializable {
@@ -22,7 +22,8 @@ sealed trait Frame extends Product with Serializable {
 }
 
 sealed trait NonEmptyFrame extends Product with Serializable
-case object Empty extends Frame
+
+case object EmptyFrame extends Frame
 final case class Complete(full: BitVector) extends Frame with NonEmptyFrame
 final case class Decoded(resp: RESP) extends Frame with NonEmptyFrame
 final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends Frame with NonEmptyFrame {

--- a/fs2/src/main/scala/laserdisc/fs2/Frame.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/Frame.scala
@@ -22,10 +22,11 @@ sealed trait Frame extends Product with Serializable {
 }
 
 sealed trait NonEmptyFrame extends Product with Serializable
+sealed trait CompleteFrame extends Product with Serializable
 
 case object EmptyFrame extends Frame
-final case class Complete(full: BitVector) extends Frame with NonEmptyFrame
-final case class Decoded(resp: RESP) extends Frame with NonEmptyFrame
+final case class Complete(full: BitVector) extends Frame with NonEmptyFrame with CompleteFrame
+final case class Decoded(resp: RESP) extends Frame with NonEmptyFrame with CompleteFrame
 final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends Frame with NonEmptyFrame {
 
   override def append(chunk: Chunk[Byte]): Exception | NonEmptyFrame = {

--- a/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
@@ -19,14 +19,18 @@ import log.effect.fs2.syntax._
 
 trait RedisClient[F[_]] {
   import Protocol.Aux
+
   def send1[A](pA: Aux[A], timeout: FiniteDuration = 20.seconds): F[Maybe[A]]
+
   def send2[A, B](pA: Aux[A], pB: Aux[B], timeout: FiniteDuration = 20.seconds): F[(Maybe[A], Maybe[B])]
+
   def send3[A, B, C](
       pA: Aux[A],
       pB: Aux[B],
       pC: Aux[C],
       timeout: FiniteDuration = 20.seconds
   ): F[(Maybe[A], Maybe[B], Maybe[C])]
+
   def send4[A, B, C, D](
       pA: Aux[A],
       pB: Aux[B],
@@ -34,6 +38,7 @@ trait RedisClient[F[_]] {
       pD: Aux[D],
       timeout: FiniteDuration = 20.seconds
   ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D])]
+
   def send5[A, B, C, D, E](
       pA: Aux[A],
       pB: Aux[B],
@@ -42,9 +47,11 @@ trait RedisClient[F[_]] {
       pE: Aux[E],
       timeout: FiniteDuration = 20.seconds
   ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D], Maybe[E])]
+
   def send[In <: HList, Out <: HList](in: In, timeout: FiniteDuration = 20.seconds)(
       implicit protocolHandler: ProtocolHandler.Aux[F, In, Out]
   ): F[Out]
+
   def sendN[CC[_] <: LinearSeq[_], A, N <: Nat, In <: HList, Out <: HList](
       sizedSeq: Sized[CC[Aux[A]], N],
       timeout: FiniteDuration = 20.seconds
@@ -65,13 +72,15 @@ object RedisClient {
       ec: ExecutionContext,
       scheduler: Scheduler
   ): Stream[F, RedisClient[F]] = {
+
     def redisConnection(address: RedisAddress): Pipe[F, RESP, RESP] =
       stream =>
         Stream
           .eval(address.toInetSocketAddress)
           .flatMap(socketAddress => stream.through(RedisConnection(socketAddress, writeTimeout, readMaxBytes)))
 
-    def connection: F[impl.Connection[F]] = impl.connection(redisConnection, impl.currentServer(addresses.toSeq))
+    def connection: F[impl.Connection[F]] =
+      impl.connection(redisConnection, impl.currentServer(addresses.toSeq))
 
     Stream.bracket(impl.mkClient(connection))(
       { case (client, _)   => Stream.emit(client) },
@@ -99,49 +108,60 @@ object RedisClient {
     def mkClient[F[_]: Effect: LogWriter](connection: F[Connection[F]])(
         implicit ec: ExecutionContext,
         scheduler: Scheduler
-    ): F[(RedisClient[F], F[Unit])] = mkPublisher(connection).map { publisher =>
-      new RedisClient[F] {
-        import Protocol.Aux
-        override final def send1[A](pA: Aux[A], timeout: FiniteDuration): F[Maybe[A]] =
-          publisher.publish(pA :: HNil, timeout).map(_.head)
-        override final def send2[A, B](pA: Aux[A], pB: Aux[B], timeout: FiniteDuration): F[(Maybe[A], Maybe[B])] =
-          publisher.publish(pA :: pB :: HNil, timeout).map(_.tupled)
-        override final def send3[A, B, C](
-            pA: Aux[A],
-            pB: Aux[B],
-            pC: Aux[C],
-            timeout: FiniteDuration
-        ): F[(Maybe[A], Maybe[B], Maybe[C])] = publisher.publish(pA :: pB :: pC :: HNil, timeout).map(_.tupled)
-        override final def send4[A, B, C, D](
-            pA: Aux[A],
-            pB: Aux[B],
-            pC: Aux[C],
-            pD: Aux[D],
-            timeout: FiniteDuration
-        ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D])] =
-          publisher.publish(pA :: pB :: pC :: pD :: HNil, timeout).map(_.tupled)
-        override final def send5[A, B, C, D, E](
-            pA: Aux[A],
-            pB: Aux[B],
-            pC: Aux[C],
-            pD: Aux[D],
-            pE: Aux[E],
-            timeout: FiniteDuration
-        ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D], Maybe[E])] =
-          publisher.publish(pA :: pB :: pC :: pD :: pE :: HNil, timeout).map(_.tupled)
-        override final def send[In <: HList, Out <: HList](in: In, timeout: FiniteDuration)(
-            implicit protocolHandler: ProtocolHandler.Aux[F, In, Out]
-        ): F[Out] = publisher.publish(in, timeout)
-        override final def sendN[CC[_] <: LinearSeq[_], A, N <: Nat, In <: HList, Out <: HList](
-            sizedSeq: Sized[CC[Aux[A]], N],
-            timeout: FiniteDuration
-        )(
-            implicit toHList: ToHList.Aux[CC[Aux[A]], N, In],
-            protocolHandler: ProtocolHandler.Aux[F, In, Out],
-            toSized: ToSized.Aux[Out, CC, Maybe[A], N]
-        ): F[Sized[CC[Maybe[A]], N]] = publisher.publish(toHList(sizedSeq), timeout).map(_.toSized)
-      } -> publisher.shutdown
-    }
+    ): F[(RedisClient[F], F[Unit])] =
+      mkPublisher(connection).map { publisher =>
+        new RedisClient[F] {
+          import Protocol.Aux
+
+          override final def send1[A](pA: Aux[A], timeout: FiniteDuration): F[Maybe[A]] =
+            publisher.publish(pA :: HNil, timeout).map(_.head)
+
+          override final def send2[A, B](pA: Aux[A], pB: Aux[B], timeout: FiniteDuration): F[(Maybe[A], Maybe[B])] =
+            publisher.publish(pA :: pB :: HNil, timeout).map(_.tupled)
+
+          override final def send3[A, B, C](
+              pA: Aux[A],
+              pB: Aux[B],
+              pC: Aux[C],
+              timeout: FiniteDuration
+          ): F[(Maybe[A], Maybe[B], Maybe[C])] =
+            publisher.publish(pA :: pB :: pC :: HNil, timeout).map(_.tupled)
+
+          override final def send4[A, B, C, D](
+              pA: Aux[A],
+              pB: Aux[B],
+              pC: Aux[C],
+              pD: Aux[D],
+              timeout: FiniteDuration
+          ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D])] =
+            publisher.publish(pA :: pB :: pC :: pD :: HNil, timeout).map(_.tupled)
+
+          override final def send5[A, B, C, D, E](
+              pA: Aux[A],
+              pB: Aux[B],
+              pC: Aux[C],
+              pD: Aux[D],
+              pE: Aux[E],
+              timeout: FiniteDuration
+          ): F[(Maybe[A], Maybe[B], Maybe[C], Maybe[D], Maybe[E])] =
+            publisher.publish(pA :: pB :: pC :: pD :: pE :: HNil, timeout).map(_.tupled)
+
+          override final def send[In <: HList, Out <: HList](in: In, timeout: FiniteDuration)(
+              implicit protocolHandler: ProtocolHandler.Aux[F, In, Out]
+          ): F[Out] = publisher.publish(in, timeout)
+
+          override final def sendN[CC[_] <: LinearSeq[_], A, N <: Nat, In <: HList, Out <: HList](
+              sizedSeq: Sized[CC[Aux[A]], N],
+              timeout: FiniteDuration
+          )(
+              implicit toHList: ToHList.Aux[CC[Aux[A]], N, In],
+              protocolHandler: ProtocolHandler.Aux[F, In, Out],
+              toSized: ToSized.Aux[Out, CC, Maybe[A], N]
+          ): F[Sized[CC[Maybe[A]], N]] =
+            publisher.publish(toHList(sizedSeq), timeout).map(_.toSized)
+
+        } -> publisher.shutdown
+      }
 
     def currentServer[F[_]: Sync](addresses: Seq[RedisAddress]): F[Option[RedisAddress]] =
       Stream.emits(addresses).covary[F].compile.last //FIXME yeah, well...
@@ -151,101 +171,110 @@ object RedisClient {
         logger: LogWriter[F],
         scheduler: Scheduler,
         ec: ExecutionContext
-    ): F[Connection[F]] = async.signalOf[F, Boolean](initialValue = false).flatMap { termSignal =>
-      async.unboundedQueue[F, Request[F]].flatMap { queue =>
-        async.refOf[F, Vector[Request[F]]](Vector.empty).map { inFlight =>
-          def push(req: Request[F]): F[RESP] = inFlight.modify2(in => (in :+ req) -> req.protocol.encode).map(_._2)
+    ): F[Connection[F]] =
+      async.signalOf[F, Boolean](initialValue = false).flatMap { termSignal =>
+        async.unboundedQueue[F, Request[F]].flatMap { queue =>
+          async.refOf[F, Vector[Request[F]]](Vector.empty).map { inFlight =>
 
-          def pop: F[Option[Request[F]]] =
-            inFlight
-              .modify2 {
-                case h +: t => t     -> Some(h)
-                case other  => other -> None
-              }
-              .map(_._2)
+            def push(req: Request[F]): F[RESP] =
+              inFlight.modify2(in => (in :+ req) -> req.protocol.encode).map(_._2)
 
-          def serverAvailable(address: RedisAddress): Stream[F, Unit] =
-            logger.infoS(s"Server available for publishing: $address") >> {
-              queue.dequeue
-                .evalMap(push)
-                .through(redisConnection(address))
-                .flatMap { resp =>
-                  Stream.eval(pop).flatMap {
-                    case None                        => Stream.raiseError[Unit](NoInflightRequest(resp))
-                    case Some(Request(protocol, cb)) => Stream.eval_(cb(Right(protocol.decode(resp))))
-                  }
-                } ++ Stream.raiseError[Unit](ServerTerminatedConnection(address))
-            }
-
-          val serverStream: Stream[F, Option[RedisAddress]] = Stream.eval(leader)
-
-          def serverUnavailable: Stream[F, RedisAddress] =
-            logger.errorS("Server unavailable for publishing") >>
-              Stream.eval(async.signalOf[F, Option[RedisAddress]](None)).flatMap { serverSignal =>
-                val cancelIncoming = queue.dequeue.evalMap(_.callback(Left(ServerUnavailable))).drain
-                val queryLeader = (scheduler.awakeEvery(3.seconds) >> serverStream) //FIXME magic number
-                  .evalMap(maybeAddress => serverSignal.modify(_ => maybeAddress))
-                  .drain
-
-                cancelIncoming
-                  .mergeHaltBoth(queryLeader)
-                  .covaryOutput[RedisAddress]
-                  .interruptWhen(serverSignal.map(_.nonEmpty)) ++ serverSignal.discrete.head.flatMap {
-                  case None          => serverUnavailable // impossible
-                  case Some(address) => logger.debugS(s"Publisher got address: $address") >> Stream.emit(address)
+            def pop: F[Option[Request[F]]] =
+              inFlight
+                .modify2 {
+                  case h +: t => t     -> Some(h)
+                  case other  => other -> None
                 }
-              }
+                .map(_._2)
 
-          def runner(knownServer: Stream[F, Option[RedisAddress]],
-                     lastFailedServer: Option[RedisAddress] = None): Stream[F, Unit] =
-            knownServer.flatMap {
-              case None => serverUnavailable.flatMap(address => runner(Stream.emit(Some(address))))
-              case Some(address) =>
-                lastFailedServer match {
-                  case Some(failedAddress) if address == failedAddress =>
-                    // this indicates that cluster sill thinks the address is same as the one that failed us, for that reason
-                    // we have to suspend execution for while and retry in FiniteDuration
-                    logger.warnS(s"New server is same like the old one ($address): currently unavailable") >>
-                      serverUnavailable.flatMap(address => runner(Stream.emit(Some(address))))
-
-                  case _ =>
-                    // connection with address will always fail with error.
-                    // TODO so when that happens, all open requests are completed
-                    // and runner is rerun to switch likely to serverUnavailable.
-                    // as the last action runner is restarted
-                    serverAvailable(address).handleErrorWith { failure =>
-                      logger.errorS(s"Failure of publishing connection to $address", failure) >>
-                        runner(serverStream, Some(address))
+            def serverAvailable(address: RedisAddress): Stream[F, Unit] =
+              logger.infoS(s"Server available for publishing: $address") >> {
+                queue.dequeue
+                  .evalMap(push)
+                  .through(redisConnection(address))
+                  .flatMap { resp =>
+                    Stream.eval(pop).flatMap {
+                      case None                        => Stream.raiseError[Unit](NoInflightRequest(resp))
+                      case Some(Request(protocol, cb)) => Stream.eval_(cb(Right(protocol.decode(resp))))
                     }
+                  } ++ Stream.raiseError[Unit](ServerTerminatedConnection(address))
+              }
+
+            val serverStream: Stream[F, Option[RedisAddress]] =
+              Stream.eval(leader)
+
+            def serverUnavailable: Stream[F, RedisAddress] =
+              logger.errorS("Server unavailable for publishing") >>
+                Stream.eval(async.signalOf[F, Option[RedisAddress]](None)).flatMap { serverSignal =>
+                  val cancelIncoming = queue.dequeue.evalMap(_.callback(Left(ServerUnavailable))).drain
+                  val queryLeader = (scheduler.awakeEvery(3.seconds) >> serverStream) //FIXME magic number
+                    .evalMap(maybeAddress => serverSignal.modify(_ => maybeAddress))
+                    .drain
+
+                  cancelIncoming
+                    .mergeHaltBoth(queryLeader)
+                    .covaryOutput[RedisAddress]
+                    .interruptWhen(serverSignal.map(_.nonEmpty)) ++ serverSignal.discrete.head.flatMap {
+                    case None          => serverUnavailable // impossible
+                    case Some(address) => logger.debugS(s"Publisher got address: $address") >> Stream.emit(address)
+                  }
                 }
+
+            def runner(knownServer: Stream[F, Option[RedisAddress]],
+                       lastFailedServer: Option[RedisAddress] = None): Stream[F, Unit] =
+              knownServer.flatMap {
+                case None =>
+                  serverUnavailable.flatMap(address => runner(Stream.emit(Some(address))))
+
+                case Some(address) =>
+                  lastFailedServer match {
+                    case Some(failedAddress) if address == failedAddress =>
+                      // this indicates that cluster sill thinks the address is same as the one that failed us, for that reason
+                      // we have to suspend execution for while and retry in FiniteDuration
+                      logger.warnS(s"New server is same like the old one ($address): currently unavailable") >>
+                        serverUnavailable.flatMap(address => runner(Stream.emit(Some(address))))
+
+                    case _ =>
+                      // connection with address will always fail with error.
+                      // TODO so when that happens, all open requests are completed
+                      // and runner is rerun to switch likely to serverUnavailable.
+                      // as the last action runner is restarted
+                      serverAvailable(address).handleErrorWith { failure =>
+                        logger.errorS(s"Failure of publishing connection to $address", failure) >>
+                          runner(serverStream, Some(address))
+                      }
+                  }
+              }
+
+            new Connection[F] {
+              override final def run: F[Unit] =
+                logger.info("Starting connection") *>
+                  runner(serverStream).interruptWhen(termSignal).compile.drain.attempt.flatMap { r =>
+                    logger.info(s"Connection terminated: $r")
+                  }
+
+              override final def shutdown: F[Unit] =
+                logger.info("Shutting down connection") *> termSignal.set(true)
+
+              override final def send[In <: HList, Out <: HList](in: In, timeout: FiniteDuration)(
+                  implicit protocolHandler: ProtocolHandler.Aux[F, In, Out]
+              ): F[Out] = protocolHandler(in, queue -> timeout)
             }
-
-          new Connection[F] {
-            override final def run: F[Unit] =
-              logger.info("Starting connection") *>
-                runner(serverStream).interruptWhen(termSignal).compile.drain.attempt.flatMap { r =>
-                  logger.info(s"Connection terminated: $r")
-                }
-
-            override final def shutdown: F[Unit] = logger.info("Shutting down connection") *> termSignal.set(true)
-
-            override final def send[In <: HList, Out <: HList](in: In, timeout: FiniteDuration)(
-                implicit protocolHandler: ProtocolHandler.Aux[F, In, Out]
-            ): F[Out] = protocolHandler(in, queue -> timeout)
           }
         }
       }
-    }
 
     def mkPublisher[F[_]](createPublisher: => F[Connection[F]])(
         implicit F: Effect[F],
         ec: ExecutionContext
     ): F[Publisher[F]] = {
+
       final case class State(hasShutdown: Boolean, maybeConnection: Option[Connection[F]]) {
         def maybeSwapConnection(connection: Connection[F]): State =
           if (hasShutdown) this else copy(maybeConnection = Some(connection))
         def shutdown: State = copy(hasShutdown = true)
       }
+
       val emptyState = State(hasShutdown = false, None)
 
       async.refOf(emptyState).map { state =>

--- a/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
@@ -56,9 +56,8 @@ object RedisConnection {
               previous.append(chunk) match {
                 case Left(ex) => Pull.raiseError(ex)
                 case Right(f) => f match {
-                  case frame: Complete   => Pull.output1(frame) >> go(rest, Empty)
-                  case frame: Decoded    => Pull.output1(frame) >> go(rest, Empty)
-                  case frame: Incomplete => go(rest, frame)
+                  case frame @ (Complete(_) | Decoded(_)) => Pull.output1(frame) >> go(rest, Empty)
+                  case frame: Incomplete                  => go(rest, frame)
                 }
               }
 

--- a/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
@@ -85,7 +85,7 @@ object RedisConnection {
       nextFrame(BitVector.view(chunk.toByteBuffer))
 
     protected final def nextFrame(bits: BitVector): Exception | NonEmptyFrame =
-      RESP.receivedAll(bits) map {
+      RESP.areAllReceived(bits) map {
         case (complete, n) => if (!complete) Incomplete(bits, n) else Complete(bits)
       } leftMap (new Exception(_))
   }
@@ -93,7 +93,7 @@ object RedisConnection {
 
   final type Empty = Empty.type
   final case object Empty extends Frame
-  
+
   final case class Complete(full: BitVector) extends Frame with NonEmptyFrame
   final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends Frame with NonEmptyFrame {
 

--- a/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
+++ b/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
@@ -23,12 +23,16 @@ import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
 import scala.concurrent.ExecutionContext
 
+/**
+  * This test will be enabled back when the docker support
+  * for the CI tests will be complete
+  */
 final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = super.beforeAll()
   override def afterAll(): Unit = super.afterAll()
 
-  "an fs2 redis client" should {
+  "an fs2 redis client" ignore {
 
     "handle correctly hundreds of read requests in parallel for a bulk text payload" in {
 

--- a/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
+++ b/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
@@ -14,8 +14,10 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
 import fs2.{Scheduler, Stream}
-import laserdisc.{Key, strings}
+import laserdisc.protocol.Show
+import laserdisc.{Key, lists, strings}
 import log.effect.fs2.Fs2LogWriter.noOpLogStream
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
@@ -28,7 +30,7 @@ final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAft
 
   "an fs2 redis client" should {
 
-    "handle one hundred of read requests in parallel for a long text payload without loss" in {
+    "handle correctly hundreds of read requests in parallel for a bulk text payload" in {
 
       val asyncChannelGroup: AsynchronousChannelGroup =
         withThreadPool(newFixedThreadPool(16))
@@ -48,7 +50,7 @@ final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAft
         cl.send1(strings.set(testKey, testPayload)) flatMap (_ => F.unit)
 
       def testRequests[F[_]](cl: RedisClient[F])(implicit F: Concurrent[F]): F[List[String]] =
-        (((1 to 100) map { _ =>
+        (((1 to 300) map { _ =>
           F.start { cl.send1(strings.get[String](testKey)) }
         }).par map { ioFib =>
           ioFib flatMap (_.join.attempt)
@@ -65,11 +67,11 @@ final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAft
           _ getOrElse Nil
         ) unsafeRunSync()
 
-      testResponses.size should be (100)
+      testResponses.size should be (300)
       testResponses map (_ should be (testPayload))
     }
 
-    "handle some read requests in a row for a long text payload" in {
+    "handle correctly some read requests in a row for a bulk text payload" in {
 
       val asyncChannelGroup: AsynchronousChannelGroup =
         withThreadPool(newFixedThreadPool(16))
@@ -106,6 +108,54 @@ final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAft
 
       testResponses.size should be (50)
       testResponses map (_ should be (testPayload))
+    }
+
+    "handle correctly hundreds of read requests in parallel for an array payload" in {
+
+      implicit object myShow1 extends Show[List[String]] {
+        final def show(a: List[String]): String = a mkString ","
+      }
+
+      val asyncChannelGroup: AsynchronousChannelGroup =
+        withThreadPool(newFixedThreadPool(16))
+
+      val redisClientPool: ExecutionContext =
+        ExecutionContext.fromExecutor(new ForkJoinPool())
+
+      val testKey  = Key.unsafeFrom("test-key-list")
+      val testBulk = (1 to 1000).toList map (_ => "test text") mkString " - "
+
+      def clientUnderTest[F[_]](implicit F: Effect[F]): Stream[F, RedisClient[F]] =
+        (noOpLogStream[F] zip Scheduler[F](corePoolSize = 4)) flatMap {
+          case (l, sch) => RedisClient[F](Set(RedisAddress("127.0.0.1", 6379)))(F, l, asyncChannelGroup, redisClientPool, sch)
+        }
+
+      def testCleanup[F[_]](cl: RedisClient[F])(implicit F: Monad[F]): F[Unit] =
+        cl.send1(lists.lrem(testKey, 0L, testBulk)) flatMap (_ => F.unit)
+
+      def testPreset[F[_]](cl: RedisClient[F])(implicit F: Monad[F]): F[Unit] =
+        (1 to 100).map(_ => cl.send1(lists.rpush(testKey, testBulk :: Nil))).toList.sequence flatMap (_ => F.unit)
+
+      def testRequests[F[_]](cl: RedisClient[F])(implicit F: Concurrent[F]): F[List[String]] =
+        (((1 to 50) map { _ =>
+          F.start { cl.send1(lists.lrange[String](testKey, 0L, 1000L)) }
+        }).par map { ioFib =>
+          ioFib flatMap (_.join.attempt)
+        } map {
+          _.map(
+            _.fold(_ => Nil, _.fold(_ => Nil, _.toList))
+          )
+        }).toList.sequence map (_.flatten)
+
+      val testResponses =
+        (clientUnderTest[IO] evalMap {
+          cl => testCleanup(cl) *> testPreset(cl) *> testRequests(cl)
+        }).compile.last map (
+          _ getOrElse Nil
+        ) unsafeRunSync()
+
+      testResponses.size should be (50 * 100)
+      testResponses map (_ should be (testBulk))
     }
   }
 }

--- a/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
+++ b/fs2/src/test/scala/laserdisc/fs2/RedisClientSpec.scala
@@ -1,0 +1,111 @@
+package laserdisc.fs2
+
+import java.nio.channels.AsynchronousChannelGroup
+import java.nio.channels.AsynchronousChannelGroup.withThreadPool
+import java.util.concurrent.Executors.newFixedThreadPool
+import java.util.concurrent.ForkJoinPool
+
+import cats.Monad
+import cats.effect.{Concurrent, Effect, IO}
+import cats.instances.list._
+import cats.syntax.applicativeError._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import eu.timepit.refined.auto._
+import fs2.{Scheduler, Stream}
+import laserdisc.{Key, strings}
+import log.effect.fs2.Fs2LogWriter.noOpLogStream
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+
+import scala.concurrent.ExecutionContext
+
+final class RedisClientSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = super.beforeAll()
+  override def afterAll(): Unit = super.afterAll()
+
+  "an fs2 redis client" should {
+
+    "handle one hundred of read requests in parallel for a long text payload without loss" in {
+
+      val asyncChannelGroup: AsynchronousChannelGroup =
+        withThreadPool(newFixedThreadPool(16))
+
+      val redisClientPool: ExecutionContext =
+        ExecutionContext.fromExecutor(new ForkJoinPool())
+
+      val testKey     = Key.unsafeFrom("test-key")
+      val testPayload = (1 to 1000).toList map (_ => "test text") mkString " - "
+
+      def clientUnderTest[F[_]](implicit F: Effect[F]): Stream[F, RedisClient[F]] =
+        (noOpLogStream[F] zip Scheduler[F](corePoolSize = 4)) flatMap {
+          case (l, sch) => RedisClient[F](Set(RedisAddress("127.0.0.1", 6379)))(F, l, asyncChannelGroup, redisClientPool, sch)
+        }
+
+      def testPreset[F[_]](cl: RedisClient[F])(implicit F: Monad[F]): F[Unit] =
+        cl.send1(strings.set(testKey, testPayload)) flatMap (_ => F.unit)
+
+      def testRequests[F[_]](cl: RedisClient[F])(implicit F: Concurrent[F]): F[List[String]] =
+        (((1 to 100) map { _ =>
+          F.start { cl.send1(strings.get[String](testKey)) }
+        }).par map { ioFib =>
+          ioFib flatMap (_.join.attempt)
+        } map {
+          _.map(
+            _.fold(_ => "", _.fold(_ => "", _.getOrElse("")))
+          )
+        }).toList.sequence
+
+      val testResponses =
+        (clientUnderTest[IO] evalMap {
+          cl => testPreset(cl) *> testRequests(cl)
+        }).compile.last map (
+          _ getOrElse Nil
+        ) unsafeRunSync()
+
+      testResponses.size should be (100)
+      testResponses map (_ should be (testPayload))
+    }
+
+    "handle some read requests in a row for a long text payload" in {
+
+      val asyncChannelGroup: AsynchronousChannelGroup =
+        withThreadPool(newFixedThreadPool(16))
+
+      val redisClientPool: ExecutionContext =
+        ExecutionContext.fromExecutor(new ForkJoinPool())
+
+      val testKey     = Key.unsafeFrom("test-key")
+      val testPayload = (1 to 1000).toList map (_ => "test text") mkString " - "
+
+      def clientUnderTest[F[_]](implicit F: Effect[F]): Stream[F, RedisClient[F]] =
+        (noOpLogStream[F] zip Scheduler[F](corePoolSize = 4)) flatMap {
+          case (l, sch) => RedisClient[F](Set(RedisAddress("127.0.0.1", 6379)))(F, l, asyncChannelGroup, redisClientPool, sch)
+        }
+
+      def testPreset[F[_]](cl: RedisClient[F])(implicit F: Monad[F]): F[Unit] =
+        cl.send1(strings.set(testKey, testPayload)) flatMap (_ => F.unit)
+
+      def testRequests[F[_]](cl: RedisClient[F])(implicit F: Concurrent[F]): F[List[String]] =
+        ((1 to 50) map { _ =>
+           cl.send1(strings.get[String](testKey)) map (
+             _.fold(_ => "", _.getOrElse(""))
+           )
+        }).toList.sequence.attempt map (
+          _.fold(_ => Nil, identity)
+        )
+
+      val testResponses =
+        (clientUnderTest[IO] evalMap {
+          cl => testPreset(cl) *> testRequests(cl)
+        }).compile.last map (
+          _ getOrElse Nil
+        ) unsafeRunSync()
+
+      testResponses.size should be (50)
+      testResponses map (_ should be (testPayload))
+    }
+  }
+}


### PR DESCRIPTION
This fixes a problem that prevents decoding bulk strings and arrays. Below is an example of the stack trace when the problem occurs.

```
[info] scodec.stream.decode.DecodingError: cannot acquire 12336 bits from a vector that contains 7336 bits
[info]  at scodec.stream.decode.package$.raiseError(package.scala:27)
[info]  at scodec.stream.decode.package$.$anonfun$runDecode$1(package.scala:88)
[info]  at scodec.Attempt$Failure.fold(Attempt.scala:113)
[info]  at scodec.stream.decode.package$.runDecode(package.scala:89)
[info]  at scodec.stream.decode.package$.$anonfun$once$1(package.scala:94)
[info]  at scala.Function1.$anonfun$andThen$1(Function1.scala:52)
[info]  at fs2.Stream$InvariantOps$.$anonfun$flatMap$1(Stream.scala:1878)
[info]  at fs2.internal.FreeC.$anonfun$flatMap$1(FreeC.scala:16)
[info]  at fs2.internal.FreeC$.$anonfun$mkViewL$1(FreeC.scala:118)
[info]  at fs2.internal.FreeC$.go$1(FreeC.scala:114)
[info]  at fs2.internal.FreeC$.fs2$internal$FreeC$$mkViewL(FreeC.scala:121)
[info]  at fs2.internal.FreeC.viewL(FreeC.scala:54)
[info]  at fs2.internal.Algebra$.translate0(Algebra.scala:480)
[info]  at fs2.internal.Algebra$.$anonfun$translate0$3(Algebra.scala:512)
[info]  at fs2.internal.FreeC.$anonfun$transformWith$1(FreeC.scala:24)
[info]  at fs2.internal.FreeC$.$anonfun$mkViewL$1(FreeC.scala:118)
[info]  at fs2.internal.Algebra$.$anonfun$compileLoop$14(Algebra.scala:307)
[info]  at fs2.internal.Algebra$.$anonfun$compileLoop$3(Algebra.scala:261)
[info]  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:128)
[info]  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:310)
[info]  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:292)
[info]  at cats.effect.internals.Callback$AsyncIdempotentCallback$$anon$3.run(Callback.scala:142)
[info]  at cats.effect.internals.TrampolineEC.cats$effect$internals$TrampolineEC$$localRunLoop(TrampolineEC.scala:62)
[info]  at cats.effect.internals.TrampolineEC.$anonfun$execute$1(TrampolineEC.scala:54)
[info]  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
[info]  at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:81)
[info]  at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:54)
[info]  at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:139)
[info]  at cats.effect.internals.Callback$AsyncIdempotentCallback.apply(Callback.scala:130)
[info]  at cats.effect.Async$$anon$7.run(Async.scala:163)
[info]  at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:140)
[info]  at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
[info]  at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
[info]  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
[info]  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
[info] 2018-07-19 17:07:20,563 [WARN] [scala-execution-context-global-29] Server New server is same like the old one (127.0.0.1:6379): currently unavailable
```