### PR TITLE
Fix array decoding

### DIFF
--- a/core/src/main/scala/laserdisc/protocol/BitVectorSyntax.scala
+++ b/core/src/main/scala/laserdisc/protocol/BitVectorSyntax.scala
@@ -9,8 +9,18 @@ private[protocol] trait BitVectorSyntax {
 
 final private[protocol] class BitVectorSyntaxOps(private val bv: BitVector) extends AnyVal {
 
-  def print: String = {
-    val printedSize = 48L * 8
-    bv.takeRight(printedSize).decodeUtf8 getOrElse "!! unable to represent the content as UTF8 string !!"
+  /**
+    * Tries to decode the last `takeRight` bytes of the bit vector as UTF8 text
+    * If not passed it defaults to 48 bytes
+    */
+  def tailToUtf8(takeRight: Long = 48L): String = {
+    bv.takeRight(takeRight * 8).decodeUtf8 getOrElse "!! unable to represent the content as UTF8 string !!"
+  }
+
+  /**
+    * Tries to decode the whole bit vector to UTF8 text
+    */
+  def toUtf8: String = {
+    bv.decodeUtf8 getOrElse "!! unable to represent the content as UTF8 string !!"
   }
 }

--- a/core/src/main/scala/laserdisc/protocol/BitVectorSyntax.scala
+++ b/core/src/main/scala/laserdisc/protocol/BitVectorSyntax.scala
@@ -10,7 +10,7 @@ private[protocol] trait BitVectorSyntax {
 final private[protocol] class BitVectorSyntaxOps(private val bv: BitVector) extends AnyVal {
 
   def print: String = {
-    val printedSize = 16L * 8
+    val printedSize = 48L * 8
     bv.takeRight(printedSize).decodeUtf8 getOrElse "!! unable to represent the content as UTF8 string !!"
   }
 }

--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -471,8 +471,7 @@ sealed trait RESPFunctions { this: RESPCodecs =>
           case Right(st) => st match {
 
             case CompleteWithRemainder(c, r) =>
-              if (stillMissing == 1) Right(CompleteWithRemainder(soFar ++ c, r))
-              else stateOfArray(stillMissing - 1, r, soFar ++ c)
+              stateOfArray(stillMissing - 1, r, soFar ++ c)
 
             case Complete =>
               if (stillMissing == 1) Right(Complete)

--- a/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
@@ -19,7 +19,7 @@ sealed trait RESPFrame extends Product with Serializable with EitherSyntax with 
       case Incomplete                  => IncompleteFrame(bits, 0L).asRight
       case Complete                    => CompleteFrame(bits).asRight
       case CompleteWithRemainder(c, r) => consumeRemainder(MoreThanOneFrame(CompleteFrame(c) :: Nil, r).asRight)
-    } leftMap (e => new Exception(s"Error building the frame: $e. Content: ${bits.print}"))
+    } leftMap (e => new Exception(s"Error building the frame: $e. Content: ${bits.tailToUtf8()}"))
 
   @tailrec
   private final def consumeRemainder(current: String | MoreThanOneFrame): String | MoreThanOneFrame =

--- a/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
@@ -15,14 +15,14 @@ sealed trait RESPFrame extends Product with Serializable with EitherSyntax with 
 
   protected final def nextFrame(bits: BitVector): Exception | NonEmptyRESPFrame =
     RESP.stateOf(bits) flatMap {
-      case MissingBits(n)              => Incomplete(bits, n).asRight
-      case IncompleteVector            => Incomplete(bits, 0L).asRight
-      case CompleteVector              => Complete(bits).asRight
-      case CompleteWithRemainder(c, r) => consumeRemainder(MoreThanOne(Complete(c) :: Nil, r).asRight)
+      case MissingBits(n)              => IncompleteFrame(bits, n).asRight
+      case Incomplete                  => IncompleteFrame(bits, 0L).asRight
+      case Complete                    => CompleteFrame(bits).asRight
+      case CompleteWithRemainder(c, r) => consumeRemainder(MoreThanOneFrame(CompleteFrame(c) :: Nil, r).asRight)
     } leftMap (e => new Exception(s"Error building the frame: $e. Content: ${bits.print}"))
 
   @tailrec
-  private final def consumeRemainder(current: String | MoreThanOne): String | MoreThanOne =
+  private final def consumeRemainder(current: String | MoreThanOneFrame): String | MoreThanOneFrame =
     current match {
       case Left(e)  => e.asLeft
       case Right(s) => RESP.stateOf(s.remainder) match {
@@ -30,35 +30,37 @@ sealed trait RESPFrame extends Product with Serializable with EitherSyntax with 
         case Right(rs) => rs match {
 
           case CompleteWithRemainder(c, r) =>
-            consumeRemainder(MoreThanOne(Complete(c) :: s.invertedComplete, r).asRight)
+            consumeRemainder(
+              MoreThanOneFrame(CompleteFrame(c) :: s.invertedComplete, r).asRight
+            )
 
-          case CompleteVector =>
-            MoreThanOne(Complete(s.remainder) :: s.invertedComplete, BitVector.empty).asRight
+          case Complete =>
+            MoreThanOneFrame(CompleteFrame(s.remainder) :: s.invertedComplete, BitVector.empty).asRight
 
-          case MissingBits(_) | IncompleteVector =>
+          case MissingBits(_) | Incomplete =>
             s.asRight
         }
       }
     }
 }
 
-sealed trait NonEmptyRESPFrame extends Product with Serializable
+private[protocol] sealed trait NonEmptyRESPFrame extends Product with Serializable
 
 case object EmptyFrame extends RESPFrame
 
-final case class Complete(full: BitVector) extends RESPFrame with NonEmptyRESPFrame
-final case class MoreThanOne(private[protocol] val invertedComplete: List[Complete], remainder: BitVector) extends RESPFrame with NonEmptyRESPFrame {
-  def complete: Vector[Complete] =
-    invertedComplete.foldRight(Vector.empty[Complete])((c, v) => v :+ c)
+final case class CompleteFrame(bits: BitVector) extends RESPFrame with NonEmptyRESPFrame
+final case class MoreThanOneFrame(private[protocol] val invertedComplete: List[CompleteFrame], remainder: BitVector) extends RESPFrame with NonEmptyRESPFrame {
+  def complete: Vector[CompleteFrame] =
+    invertedComplete.foldRight(Vector.empty[CompleteFrame])((c, v) => v :+ c)
 }
-final case class Incomplete(partial: BitVector, bitsToComplete: Long) extends RESPFrame with NonEmptyRESPFrame {
+final case class IncompleteFrame(partial: BitVector, bitsToComplete: Long) extends RESPFrame with NonEmptyRESPFrame {
 
   override def append(bytes: ByteBuffer): Exception | NonEmptyRESPFrame = {
 
     val newBits = BitVector.view(bytes)
 
     //  Saves some size checks
-    if (bitsToComplete > 0 && bitsToComplete == newBits.size) Complete(partial ++ newBits).asRight
+    if (bitsToComplete > 0 && bitsToComplete == newBits.size) CompleteFrame(partial ++ newBits).asRight
     else nextFrame(partial ++ newBits)
   }
 }

--- a/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
@@ -37,7 +37,6 @@ sealed trait RESPFrame extends Product with Serializable with EitherSyntax with 
 
           case MissingBits(_) | IncompleteVector =>
             MoreThanOne(s.invertedComplete, s.remainder).asRight
-
         }
       }
     }
@@ -50,7 +49,7 @@ case object EmptyFrame extends RESPFrame
 
 final case class Complete(full: BitVector) extends RESPFrame with NonEmptyRESPFrame with CompleteRESPFrame
 final case class Decoded(resp: RESP) extends RESPFrame with NonEmptyRESPFrame with CompleteRESPFrame
-final case class MoreThanOne(private[protocol] val invertedComplete: List[Complete], remainder: BitVector) extends RESPFrame with NonEmptyRESPFrame { self =>
+final case class MoreThanOne(private[protocol] val invertedComplete: List[Complete], remainder: BitVector) extends RESPFrame with NonEmptyRESPFrame {
   def complete: Vector[Complete] =
     invertedComplete.foldRight(Vector.empty[Complete])((c, v) => v :+ c)
 }

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
@@ -1,19 +1,135 @@
 package laserdisc.protocol
 
+import laserdisc.protocol
 import org.scalatest.{Matchers, WordSpecLike}
 import scodec.bits.BitVector
 
 final class RESPFrameArraySpec extends WordSpecLike with Matchers {
 
+  "An empty Array Frame" when {
+
+    "appending a bit vector that represent an empty array" should {
+      "produce a complete frame with the bits of an empty bulk" in {
+        val inputVector = BitVector("*0\r\n".getBytes)
+        EmptyFrame.append(inputVector.toByteBuffer) should be(Right(CompleteFrame(inputVector)))
+      }
+    }
+  }
+
   "A non empty Array Frame" when {
 
     "appending a bit vector that completes it" should {
-      "produce Complete with all the bits" in {
+      "produce a complete frame with the correct bits" in {
         val nonEmptyFrame = IncompleteFrame(BitVector("*1\r\n$16\r\nTest bulk str".getBytes), 0)
         val inputVector = BitVector("ing\r\n".getBytes)
         val expected = BitVector("*1\r\n$16\r\nTest bulk string\r\n".getBytes)
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(CompleteFrame(expected)))
       }
     }
+
+    "appending a bit vector that doesn't complete the array but has complete objects" should {
+      "produce an incomplete frame with the correct partial and 0 as missing count" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n".getBytes)
+        val expected = BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(IncompleteFrame(expected, 0)))
+      }
+    }
+
+    "appending a bit vector that completes the array" should {
+      "produce a complete frame with the correct bits" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n".getBytes)
+        val expected = BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(protocol.CompleteFrame(expected)))
+      }
+    }
+
+    "appending a bit vector with more than one array" should {
+      "produce more than one frame with a list of the complete ones and an empty remainder" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOneFrame(
+            CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+            BitVector.empty
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with more than one array plus a reminder" should {
+      "produce more than one frame with a list of the complete ones and the correct remainder" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n*2\r\n$8\r\nAnother1\r\n-An error\r\n$17\r\nAnother bulk ".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOneFrame(
+            CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+            BitVector("$17\r\nAnother bulk ".getBytes())
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple null arrays" should {
+      "produce more than one frame with a list of the complete ones and the correct remainder" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n*-1\r\n*-1\r\n*-1\r\n*-1\r\n*-1\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOneFrame(
+            CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+            BitVector.empty
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple null arrays the last of which not complete" should {
+      "produce more than one frame with a list of the complete ones and the correct remainder" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n*-1\r\n*-1\r\n*-1\r\n*-1\r\n*-1\r\n*".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOneFrame(
+            CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+            BitVector("*".getBytes())
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple arrays interleaved with null arrays" should {
+      "produce as result of `complete` more than one frame with a list of the complete arrays in the correct order" in {
+        val nonEmptyFrame = IncompleteFrame(BitVector("*3\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n:100\r\n+A simple string\r\n*-1\r\n*-1\r\n*2\r\n$8\r\nAnother1\r\n-An error\r\n*-1\r\n*-1\r\n*-1\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer).fold(
+          err => fail(s"expected a result but failed with $err"),
+          {
+            case r@MoreThanOneFrame(_, _) => r.complete shouldBe Vector(
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
+              CompleteFrame(BitVector("*-1\r\n".getBytes)),
+              CompleteFrame(BitVector("*-1\r\n".getBytes)),
+              CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)),
+              CompleteFrame(BitVector("*-1\r\n".getBytes)),
+              CompleteFrame(BitVector("*-1\r\n".getBytes)),
+              CompleteFrame(BitVector("*-1\r\n".getBytes))
+            )
+            case _ => fail(s"expected a MoreThanOne type")
+          }
+        )
+      }
+    }
+
   }
 }

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
@@ -1,0 +1,19 @@
+package laserdisc.protocol
+
+import org.scalatest.{Matchers, WordSpecLike}
+import scodec.bits.BitVector
+
+final class RESPFrameArraySpec extends WordSpecLike with Matchers {
+
+  "A non empty Array Frame" when {
+
+    "appending a bit vector that completes it" should {
+      "produce Complete with all the bits" in {
+        val nonEmptyFrame = Incomplete(BitVector("*1\r\n$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n".getBytes)
+        val expected = BitVector("*1\r\n$16\r\nTest bulk string\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(Complete(expected)))
+      }
+    }
+  }
+}

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameArraySpec.scala
@@ -9,10 +9,10 @@ final class RESPFrameArraySpec extends WordSpecLike with Matchers {
 
     "appending a bit vector that completes it" should {
       "produce Complete with all the bits" in {
-        val nonEmptyFrame = Incomplete(BitVector("*1\r\n$16\r\nTest bulk str".getBytes), 0)
+        val nonEmptyFrame = IncompleteFrame(BitVector("*1\r\n$16\r\nTest bulk str".getBytes), 0)
         val inputVector = BitVector("ing\r\n".getBytes)
         val expected = BitVector("*1\r\n$16\r\nTest bulk string\r\n".getBytes)
-        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(Complete(expected)))
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(CompleteFrame(expected)))
       }
     }
   }

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameBulkStringSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameBulkStringSpec.scala
@@ -14,6 +14,13 @@ final class RESPFrameBulkStringSpec extends WordSpecLike with Matchers {
       }
     }
 
+    "appending a bit vector that represent an empty bulk" should {
+      "produce Complete with a empty content" in {
+        val inputVector = BitVector("$0\r\n\r\n".getBytes)
+        EmptyFrame.append(inputVector.toByteBuffer) should be(Right(Complete(inputVector)))
+      }
+    }
+
     "appending a bit vector that's not complete" should {
       "produce Incomplete with the correct partial and the correct missing count" in {
         val inputVector = BitVector("$16\r\nTest bulk string".getBytes)

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameBulkStringSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameBulkStringSpec.scala
@@ -3,7 +3,7 @@ package laserdisc.protocol
 import org.scalatest.{Matchers, WordSpecLike}
 import scodec.bits.BitVector
 
-final class RESPFrameSpec extends WordSpecLike with Matchers {
+final class RESPFrameBulkStringSpec extends WordSpecLike with Matchers {
 
   "An empty BulkString Frame" when {
 
@@ -16,8 +16,8 @@ final class RESPFrameSpec extends WordSpecLike with Matchers {
 
     "appending a bit vector that's not complete" should {
       "produce Incomplete with the correct partial and the correct missing count" in {
-        val inputVector = BitVector("$16\r\nTest bulk str".getBytes)
-        EmptyFrame.append(inputVector.toByteBuffer) should be(Right(Incomplete(inputVector, 40)))
+        val inputVector = BitVector("$16\r\nTest bulk string".getBytes)
+        EmptyFrame.append(inputVector.toByteBuffer) should be(Right(Incomplete(inputVector, 16)))
       }
     }
 
@@ -208,6 +208,5 @@ final class RESPFrameSpec extends WordSpecLike with Matchers {
         )
       }
     }
-
   }
 }

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
@@ -13,22 +13,22 @@ final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyC
 
     "appending a bit vector composed of a complete sequence of integers, simple strings, bulk strings and errors" should {
       "produce MoreThanOne with a list of all the complete items" in {
-        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk str".getBytes), 0)
+        val nonEmptyFrame = IncompleteFrame(BitVector("$16\r\nTest bulk str".getBytes), 0)
         val inputVector = BitVector("ing\r\n+OK\r\n+Another simple string\r\n-Possible error message\r\n:1\r\n:2\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n-And an error message\r\n".getBytes)
         nonEmptyFrame.append(inputVector.toByteBuffer).fold(
           err => fail(s"expected a result but failed with $err"),
           {
-            case r@MoreThanOne(_, _) => r.complete shouldBe Vector(
-              Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
-              Complete(BitVector("+OK\r\n".getBytes())),
-              Complete(BitVector("+Another simple string\r\n".getBytes())),
-              Complete(BitVector("-Possible error message\r\n".getBytes())),
-              Complete(BitVector(":1\r\n".getBytes())),
-              Complete(BitVector(":2\r\n".getBytes())),
-              Complete(BitVector(":177\r\n".getBytes())),
-              Complete(BitVector("+Another simple string\r\n".getBytes())),
-              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
-              Complete(BitVector("-And an error message\r\n".getBytes()))
+            case r@MoreThanOneFrame(_, _) => r.complete shouldBe Vector(
+              CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
+              CompleteFrame(BitVector("+OK\r\n".getBytes())),
+              CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
+              CompleteFrame(BitVector("-Possible error message\r\n".getBytes())),
+              CompleteFrame(BitVector(":1\r\n".getBytes())),
+              CompleteFrame(BitVector(":2\r\n".getBytes())),
+              CompleteFrame(BitVector(":177\r\n".getBytes())),
+              CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
+              CompleteFrame(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              CompleteFrame(BitVector("-And an error message\r\n".getBytes()))
             )
             case _ => fail(s"expected a MoreThanOne type")
           }
@@ -38,22 +38,22 @@ final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyC
 
     "appending a bit vector composed of sequence of integers, simple strings, bulk strings and errors that are not complete" should {
       "produce MoreThanOne with a list of all the complete items plus the remainder" in {
-        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk str".getBytes), 0)
+        val nonEmptyFrame = IncompleteFrame(BitVector("$16\r\nTest bulk str".getBytes), 0)
         val inputVector = BitVector("ing\r\n+OK\r\n+Another simple string\r\n-Possible error message\r\n:1\r\n:2\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n-And an error message\r\n".getBytes)
         nonEmptyFrame.append(inputVector.toByteBuffer).fold(
           err => fail(s"expected a result but failed with $err"),
           {
-            case r@MoreThanOne(_, _) => r.complete shouldBe Vector(
-              Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
-              Complete(BitVector("+OK\r\n".getBytes())),
-              Complete(BitVector("+Another simple string\r\n".getBytes())),
-              Complete(BitVector("-Possible error message\r\n".getBytes())),
-              Complete(BitVector(":1\r\n".getBytes())),
-              Complete(BitVector(":2\r\n".getBytes())),
-              Complete(BitVector(":177\r\n".getBytes())),
-              Complete(BitVector("+Another simple string\r\n".getBytes())),
-              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
-              Complete(BitVector("-And an error message\r\n".getBytes()))
+            case r@MoreThanOneFrame(_, _) => r.complete shouldBe Vector(
+              CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
+              CompleteFrame(BitVector("+OK\r\n".getBytes())),
+              CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
+              CompleteFrame(BitVector("-Possible error message\r\n".getBytes())),
+              CompleteFrame(BitVector(":1\r\n".getBytes())),
+              CompleteFrame(BitVector(":2\r\n".getBytes())),
+              CompleteFrame(BitVector(":177\r\n".getBytes())),
+              CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
+              CompleteFrame(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              CompleteFrame(BitVector("-And an error message\r\n".getBytes()))
             )
             case _ => fail(s"expected a MoreThanOne type")
           }
@@ -73,7 +73,7 @@ final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyC
           EmptyFrame.append(vector.toByteBuffer).fold(
             err => fail(s"expected a result but failed with $err"),
             {
-              case r@MoreThanOne(_, _) =>
+              case r@MoreThanOneFrame(_, _) =>
                 r.complete.size shouldBe testSet.value.size
                 r.remainder should be (empty)
               case _ => fail(s"expected a MoreThanOne type")

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
@@ -14,20 +14,25 @@ final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyC
     "appending a bit vector composed of a complete sequence of integers, simple strings, bulk strings and errors" should {
       "produce MoreThanOne with a list of all the complete items" in {
         val nonEmptyFrame = IncompleteFrame(BitVector("$16\r\nTest bulk str".getBytes), 0)
-        val inputVector = BitVector("ing\r\n+OK\r\n+Another simple string\r\n-Possible error message\r\n:1\r\n:2\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n-And an error message\r\n".getBytes)
+        val inputVector = BitVector("ing\r\n+OK\r\n$0\r\n\r\n+Another simple string\r\n*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n-Possible error message\r\n*0\r\n:1\r\n:2\r\n*2\r\n$8\r\nAnother1\r\n-An error\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n*5\r\n$16\r\nTest bulk string\r\n:13\r\n-1234 An error with numbers\r\n:100\r\n+A simple string\r\n-And an error message\r\n".getBytes)
         nonEmptyFrame.append(inputVector.toByteBuffer).fold(
           err => fail(s"expected a result but failed with $err"),
           {
             case r@MoreThanOneFrame(_, _) => r.complete shouldBe Vector(
               CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
               CompleteFrame(BitVector("+OK\r\n".getBytes())),
+              CompleteFrame(BitVector("$0\r\n\r\n".getBytes())),
               CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
+              CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
               CompleteFrame(BitVector("-Possible error message\r\n".getBytes())),
+              CompleteFrame(BitVector("*0\r\n".getBytes())),
               CompleteFrame(BitVector(":1\r\n".getBytes())),
               CompleteFrame(BitVector(":2\r\n".getBytes())),
+              CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)),
               CompleteFrame(BitVector(":177\r\n".getBytes())),
               CompleteFrame(BitVector("+Another simple string\r\n".getBytes())),
               CompleteFrame(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              CompleteFrame(BitVector("*5\r\n$16\r\nTest bulk string\r\n:13\r\n-1234 An error with numbers\r\n:100\r\n+A simple string\r\n".getBytes)),
               CompleteFrame(BitVector("-And an error message\r\n".getBytes()))
             )
             case _ => fail(s"expected a MoreThanOne type")
@@ -118,8 +123,14 @@ final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyC
                   "+Another simple string\r\n",
                   "$21\r\nTest bulk string 1 11\r\n",
                   "$-1\r\n",
+                  "$0\r\n\r\n",
                   "-And an error message\r\n",
-                  "$21\r\nTest bulk string 1 11\r\n"
+                  "$21\r\nTest bulk string 1 11\r\n",
+                  "*5\r\n$16\r\nTest bulk string\r\n:13\r\n-1234 An error with numbers\r\n:100\r\n+A simple string\r\n",
+                  "*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n",
+                  "*2\r\n$8\r\nAnother1\r\n-An error\r\n",
+                  "*0\r\n",
+                  "*-1\r\n"
                 )
               ))
       } yield xs) map (xs => OneOrMore.unsafeFrom(xs))

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
@@ -1,0 +1,121 @@
+package laserdisc.protocol
+
+import eu.timepit.refined.types.string.NonEmptyString
+import laserdisc.OneOrMore
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, WordSpecLike}
+import scodec.bits.BitVector
+
+final class RESPFrameMixedSpec extends WordSpecLike with Matchers with PropertyChecks {
+
+  "A non empty mixed Frame" when {
+
+    "appending a bit vector composed of a complete sequence of integers, simple strings, bulk strings and errors" should {
+      "produce MoreThanOne with a list of all the complete items" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n+OK\r\n+Another simple string\r\n-Possible error message\r\n:1\r\n:2\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n-And an error message\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer).fold(
+          err => fail(s"expected a result but failed with $err"),
+          {
+            case r@MoreThanOne(_, _) => r.complete shouldBe Vector(
+              Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
+              Complete(BitVector("+OK\r\n".getBytes())),
+              Complete(BitVector("+Another simple string\r\n".getBytes())),
+              Complete(BitVector("-Possible error message\r\n".getBytes())),
+              Complete(BitVector(":1\r\n".getBytes())),
+              Complete(BitVector(":2\r\n".getBytes())),
+              Complete(BitVector(":177\r\n".getBytes())),
+              Complete(BitVector("+Another simple string\r\n".getBytes())),
+              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              Complete(BitVector("-And an error message\r\n".getBytes()))
+            )
+            case _ => fail(s"expected a MoreThanOne type")
+          }
+        )
+      }
+    }
+
+    "appending a bit vector composed of sequence of integers, simple strings, bulk strings and errors that are not complete" should {
+      "produce MoreThanOne with a list of all the complete items plus the remainder" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n+OK\r\n+Another simple string\r\n-Possible error message\r\n:1\r\n:2\r\n:177\r\n+Another simple string\r\n$21\r\nTest bulk string 1 11\r\n-And an error message\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer).fold(
+          err => fail(s"expected a result but failed with $err"),
+          {
+            case r@MoreThanOne(_, _) => r.complete shouldBe Vector(
+              Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes())),
+              Complete(BitVector("+OK\r\n".getBytes())),
+              Complete(BitVector("+Another simple string\r\n".getBytes())),
+              Complete(BitVector("-Possible error message\r\n".getBytes())),
+              Complete(BitVector(":1\r\n".getBytes())),
+              Complete(BitVector(":2\r\n".getBytes())),
+              Complete(BitVector(":177\r\n".getBytes())),
+              Complete(BitVector("+Another simple string\r\n".getBytes())),
+              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              Complete(BitVector("-And an error message\r\n".getBytes()))
+            )
+            case _ => fail(s"expected a MoreThanOne type")
+          }
+        )
+      }
+    }
+
+  }
+
+  "An empty Frame" when {
+    "appending a random sequence of complete messages" should {
+      "produce MoreThanOne with all the complete items" in {
+        forAll { content: OneOrMore[String] =>
+          EmptyFrame.append(BitVector(content.value.mkString.getBytes()).toByteBuffer).fold(
+            err => fail(s"expected a result but failed with $err"),
+            {
+              case r@MoreThanOne(_, _) =>
+                r.complete shouldNot be (empty)
+                r.remainder should be (empty)
+              case _ => fail(s"expected a MoreThanOne type")
+            }
+          )
+        }
+      }
+    }
+  }
+
+  private implicit def arbitraryNonEmptyString(implicit ev: Arbitrary[String]): Arbitrary[NonEmptyString] =
+    Arbitrary {
+      ev.arbitrary.filter(_.length > 0) map NonEmptyString.unsafeFrom
+    }
+
+  private implicit def arbitraryMessages(implicit ev1: Arbitrary[Int], ev2: Arbitrary[NonEmptyString]): Arbitrary[OneOrMore[String]] =
+    Arbitrary {
+      (for {
+        n  <- Gen.choose(2, 1000)
+        i  <- ev1.arbitrary map (n => s":$n\r\n")
+        s  <- ev2.arbitrary map (st => s"+$st\r\n")
+        e  <- ev2.arbitrary map (st => s"-$st\r\n")
+        bs <- ev2.arbitrary map (st => s"$$${st.value.length}\r\n$st\r\n")
+        xs <- Gen.listOfN(n, Gen.oneOf(
+                Seq(
+                  //i, s, e, bs,
+                  "$16\r\nTest bulk string\r\n",
+                  "+OK\r\n",
+                  "+a\r\n",
+                  "+Another simple string\r\n",
+                  "-Possible error message\r\n",
+                  "-1234 Error with numbers\r\n",
+                  ":1\r\n",
+                  ":2\r\n",
+                  ":177\r\n",
+                  ":123456789\r\n",
+                  ":-1\r\n",
+                  "+Very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long single line string\r\n",
+                  "+Another simple string\r\n",
+                  "$21\r\nTest bulk string 1 11\r\n",
+                  "$-1\r\n",
+                  "-And an error message\r\n",
+                  "$21\r\nTest bulk string 1 11\r\n$17\r\nTest bulk string2\r\n$20\r\nTest bulk string 3 1\r\n$19\r\nTest bulk string 40\r\n"
+                )
+              ))
+      } yield xs) map (xs => OneOrMore.unsafeFrom(xs))
+    }
+}

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameSpec.scala
@@ -5,7 +5,7 @@ import scodec.bits.BitVector
 
 final class RESPFrameSpec extends WordSpecLike with Matchers {
 
-  "An empty Frame" when {
+  "An empty BulkString Frame" when {
 
     "appending a bit vector that's complete" should {
       "produce Complete with all the bits" in {
@@ -95,6 +95,114 @@ final class RESPFrameSpec extends WordSpecLike with Matchers {
                 Complete(BitVector("$18\r\nTest bulk string 3\r\n".getBytes())),
                 Complete(BitVector("$18\r\nTest bulk string 4\r\n".getBytes()))
               )
+            case _ => fail(s"expected a MoreThanOne type")
+          }
+        )
+      }
+    }
+
+  }
+
+  "A non empty BulkString Frame" when {
+
+    "appending a bit vector that completes it" should {
+      "produce Complete with all the bits" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk str".getBytes), 0)
+        val inputVector = BitVector("ing\r\n".getBytes)
+        val expected = BitVector("$16\r\nTest bulk string\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(Complete(expected)))
+      }
+    }
+
+    "appending a bit vector that doesn't complete it" should {
+      "produce Incomplete with the correct partial and the correct missing count" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bul".getBytes), 0)
+        val inputVector = BitVector("k str".getBytes)
+        val expected = BitVector("$16\r\nTest bulk str".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(Right(Incomplete(expected, 40)))
+      }
+    }
+
+    "appending a bit vector with multiple messages all complete" should {
+      "produce MoreThanOne with a list of the complete ones and an empty remainder" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk s".getBytes), 0)
+        val inputVector = BitVector("tring\r\n$16\r\nTest bulk string\r\n$16\r\nTest bulk string\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOne(
+            List.fill(3)(Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+            BitVector.empty
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple messages with the last not complete" should {
+      "produce MoreThanOne with a list of the complete ones and a remainder with the incomplete bits" in {
+        val nonEmptyFrame = Incomplete(BitVector("$16\r\nTest bulk s".getBytes), 0)
+        val inputVector = BitVector("tring\r\n$16\r\nTest bulk string\r\n$16\r\nTest bulk".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOne(
+            List.fill(2)(Complete(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+            BitVector("$16\r\nTest bulk".getBytes())
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple null bulk all complete" should {
+      "produce MoreThanOne with a list of the complete ones and an empty remainder" in {
+        val nonEmptyFrame = Incomplete(BitVector("$-".getBytes), 0)
+        val inputVector = BitVector("1\r\n$-1\r\n$-1\r\n$-1\r\n$-1\r\n$-1\r\n".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOne(
+            List.fill(6)(Complete(BitVector("$-1\r\n".getBytes()))),
+            BitVector.empty
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple null bulk with the last not complete" should {
+      "produce MoreThanOne with a list of the complete ones and a remainder with the incomplete bits" in {
+        val nonEmptyFrame = Incomplete(BitVector("$-".getBytes), 0)
+        val inputVector = BitVector("1\r\n$-1\r\n$-1\r\n$-1\r\n$".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOne(
+            List.fill(4)(Complete(BitVector("$-1\r\n".getBytes()))),
+            BitVector("$".getBytes())
+          ) )
+        )
+      }
+    }
+
+    "appending a bit vector with multiple different messages with the last not complete" should {
+
+      "produce MoreThanOne with a list of the complete ones in the inverted order and a remainder with the incomplete bits" in {
+        val nonEmptyFrame = Incomplete(BitVector("$21\r\nTest bulk s".getBytes), 0)
+        val inputVector = BitVector("tring 1 11\r\n$17\r\nTest bulk string2\r\n$20\r\nTest bulk string 3 1\r\n$19\r\nTest bulk string 40\r\n$18\r\nTest bulk".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer) should be(
+          Right( MoreThanOne(
+            Complete(BitVector("$19\r\nTest bulk string 40\r\n".getBytes())) ::
+              Complete(BitVector("$20\r\nTest bulk string 3 1\r\n".getBytes())) ::
+              Complete(BitVector("$17\r\nTest bulk string2\r\n".getBytes())) ::
+              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())) :: Nil,
+            BitVector("$18\r\nTest bulk".getBytes())
+          ) )
+        )
+      }
+
+      "produce MoreThanOne where the call to complete should give a vector with the complete ones in the original order" in {
+        val nonEmptyFrame = Incomplete(BitVector("$21\r\nTest bulk s".getBytes), 0)
+        val inputVector = BitVector("tring 1 11\r\n$17\r\nTest bulk string2\r\n$20\r\nTest bulk string 3 1\r\n$19\r\nTest bulk string 40\r\n$18\r\nTest bulk".getBytes)
+        nonEmptyFrame.append(inputVector.toByteBuffer).fold(
+          err => fail(s"expected a result but failed with $err"),
+          {
+            case r@MoreThanOne(_, _) => r.complete shouldBe Vector(
+              Complete(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+              Complete(BitVector("$17\r\nTest bulk string2\r\n".getBytes())),
+              Complete(BitVector("$20\r\nTest bulk string 3 1\r\n".getBytes())),
+              Complete(BitVector("$19\r\nTest bulk string 40\r\n".getBytes()))
+            )
             case _ => fail(s"expected a MoreThanOne type")
           }
         )

--- a/core/src/test/scala/laserdisc/protocol/RESPFunctionsSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFunctionsSpec.scala
@@ -1,6 +1,6 @@
 package laserdisc.protocol
 
-import laserdisc.protocol.BitVectorDecoding.{CompleteVector, CompleteWithRemainder, IncompleteVector, MissingBits}
+import laserdisc.protocol.BitVectorDecoding.{Complete, CompleteWithRemainder, Incomplete, MissingBits}
 import org.scalatest.{Matchers, WordSpecLike}
 import scodec.bits.BitVector
 
@@ -10,19 +10,19 @@ final class RESPFunctionsSpec extends WordSpecLike with Matchers {
 
     "checking the state of a bit vector with the size prefix not complete" should {
       "produce IncompleteVector" in {
-        RESP.stateOf(BitVector("$2362".getBytes)) should be (Right(IncompleteVector))
+        RESP.stateOf(BitVector("$2362".getBytes)) should be (Right(Incomplete))
       }
     }
 
     "checking the state of a bit vector with only the data type selector" should {
       "produce IncompleteVector" in {
-        RESP.stateOf(BitVector("$".getBytes)) should be (Right(IncompleteVector))
+        RESP.stateOf(BitVector("$".getBytes)) should be (Right(Incomplete))
       }
     }
 
     "checking the state of a bit vector that's complete" should {
       "produce CompleteVector" in {
-        RESP.stateOf(BitVector("$16\r\nTest bulk string\r\n".getBytes)) should be (Right(CompleteVector))
+        RESP.stateOf(BitVector("$16\r\nTest bulk string\r\n".getBytes)) should be (Right(Complete))
       }
     }
 
@@ -34,13 +34,13 @@ final class RESPFunctionsSpec extends WordSpecLike with Matchers {
 
     "checking the state of a bit vector that represents an empty bulk" should {
       "produce CompleteVector" in {
-        RESP.stateOf(BitVector("$-1\r\n".getBytes)) should be (Right(CompleteVector))
+        RESP.stateOf(BitVector("$-1\r\n".getBytes)) should be (Right(Complete))
       }
     }
 
     "checking the state of an incomplete bit vector that represents an empty bulk" should {
       "produce MissingBits" in {
-        RESP.stateOf(BitVector("$-".getBytes)) should be (Right(IncompleteVector))
+        RESP.stateOf(BitVector("$-".getBytes)) should be (Right(Incomplete))
       }
     }
 

--- a/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisConnection.scala
@@ -10,7 +10,7 @@ import cats.Applicative
 import cats.effect.Effect
 import cats.syntax.applicative._
 import cats.syntax.apply._
-import laserdisc.protocol.{Complete, CompleteRESPFrame, Decoded, EmptyFrame, Incomplete, MoreThanOne, RESPFrame}
+import laserdisc.protocol._
 import log.effect.LogWriter
 import scodec.Codec
 import scodec.stream.{decode, encode}
@@ -48,16 +48,16 @@ object RedisConnection {
 
     def receive[F[_]: Effect](implicit log: LogWriter[F]): Pipe[F, Byte, RESP] = {
 
-      def framing: Pipe[F, Byte, CompleteRESPFrame] = {
+      def framing: Pipe[F, Byte, Complete] = {
 
-        def loopStream(stream: Stream[F, Byte], previous: RESPFrame): Pull[F, CompleteRESPFrame, Unit] =
+        def loopStream(stream: Stream[F, Byte], previous: RESPFrame): Pull[F, Complete, Unit] =
           stream.pull.unconsChunk flatMap {
 
             case Some((chunk, rest)) =>
               previous.append(chunk.toByteBuffer) match {
                 case Left(ex) => Pull.raiseError(ex)
                 case Right(f) => f match {
-                  case frame: CompleteRESPFrame =>
+                  case frame: Complete =>
                     Pull.output1(frame) >> loopStream(rest, EmptyFrame)
 
                   case frame: MoreThanOne =>
@@ -77,10 +77,9 @@ object RedisConnection {
         stream => loopStream(stream, EmptyFrame).stream
       }
 
-      _.through(framing) flatMap {
-        case Complete(v)      => streamDecoder.decode(v)
-        case Decoded(s)       => Stream.emit(s)
-      } evalMap (
+      _.through(framing) flatMap ( complete =>
+        streamDecoder.decode(complete.full)
+      ) evalMap (
         resp => log.debug(s"receiving $resp") *> resp.pure
       )
     }


### PR DESCRIPTION
This should sort out the issues while decoding arrays. I tested it a bit locally against a Redis on the cloud and went ok. I could also simplify a lot the framing logic.
```
Transactions:		      131227 hits
Availability:		      100.00 %
Elapsed time:		      599.95 secs
Data transferred:	        0.00 MB
Response time:		        0.11 secs
Transaction rate:	      218.73 trans/sec
Throughput:		        0.00 MB/sec
Concurrency:		       24.95
Successful transactions:      131227
Failed transactions:	           0
Longest transaction:	        0.50
Shortest transaction:	        0.09
```
```
Transactions:		      128382 hits
Availability:		      100.00 %
Elapsed time:		      599.16 secs
Data transferred:	        0.00 MB
Response time:		        0.12 secs
Transaction rate:	      214.27 trans/sec
Throughput:		        0.00 MB/sec
Concurrency:		       24.92
Successful transactions:      128382
Failed transactions:	           0
Longest transaction:	        0.75
Shortest transaction:	        0.09
```