### PR TITLE
Getting badge version from Maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Join the chat at https://gitter.im/laserdisc-io/laserdisc](https://badges.gitter.im/laserdisc-io/laserdisc.svg)](https://gitter.im/laserdisc-io/laserdisc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 <br>
-[![Latest core version](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-core/latest.svg?color=orange&v=1)](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-core)
-[![Javadocs](https://javadoc.io/badge/io.laserdisc/laserdisc-core_2.12.svg?color=orange&label=laserdisc-core-docs)](https://javadoc.io/doc/io.laserdisc/laserdisc-core_2.12)
-[![Latest fs2 version](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-fs2/latest.svg?color=blue&v=1)](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-fs2)
-[![Javadocs](https://javadoc.io/badge/io.laserdisc/laserdisc-fs2_2.12.svg?color=blue&label=laserdisc-fs2-docs)](https://javadoc.io/doc/io.laserdisc/laserdisc-fs2_2.12)
+[![Maven Central](https://img.shields.io/maven-central/v/io.laserdisc/laserdisc-core_2.12.svg?label=laserdisc-core&colorB=orange)](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-core)
+[![Maven Central](https://img.shields.io/maven-central/v/io.laserdisc/laserdisc-core_2.12.svg?label=laserdisc-core-docs&colorB=orange)](https://javadoc.io/doc/io.laserdisc/laserdisc-core_2.12)
+[![Maven Central](https://img.shields.io/maven-central/v/io.laserdisc/laserdisc-fs2_2.12.svg?label=laserdisc-fs2&colorB=blue)](https://index.scala-lang.org/laserdisc-io/laserdisc/laserdisc-fs2)
+[![Maven Central](https://img.shields.io/maven-central/v/io.laserdisc/laserdisc-core_2.12.svg?label=laserdisc-fs2-docs&colorB=blue)](https://javadoc.io/doc/io.laserdisc/laserdisc-fs2_2.12)
 [![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.17.svg)](http://scala-js.org)
 
 LaserDisc is a(nother) Scala driver for [Redis](https://redis.io/), written in Scala from the ground up.


### PR DESCRIPTION
I released 2 versions yesterday afternoon and the badges are still at 0.1.12 

<img width="1286" alt="screen shot 2018-08-17 at 00 27 07" src="https://user-images.githubusercontent.com/201339/44240094-6c6bf600-a1b4-11e8-9444-41a28af5d5ef.png">
