### PR TITLE
promote cli as module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -248,9 +248,18 @@ lazy val `core-bench` = project
     publishArtifact := false
   )
 
+lazy val cli = project
+  .in(file("cli"))
+  .dependsOn(fs2)
+  .settings(allSettings)
+  .settings(
+    name := "laserdisc-cli",
+    libraryDependencies ++= fs2Deps.value
+  )
+
 lazy val laserdisc = project
   .in(file("."))
-  .aggregate(coreJVM, coreJS, fs2)
+  .aggregate(coreJVM, coreJS, fs2, cli)
   .settings(publishSettings)
   .settings(
     publishArtifact := false

--- a/cli/src/main/scala/laserdisc/cli/CLI.scala
+++ b/cli/src/main/scala/laserdisc/cli/CLI.scala
@@ -1,4 +1,5 @@
-package laserdisc.cli
+package laserdisc
+package cli
 
 import java.nio.channels.AsynchronousChannelGroup.withThreadPool
 import java.util.concurrent.Executors._
@@ -13,7 +14,6 @@ import scala.concurrent.ExecutionContext.fromExecutorService
 import scala.reflect.runtime.universe
 import scala.tools.reflect.ToolBox
 
-import laserdisc._
 import laserdisc.fs2._
 
 object CLI extends IOApp.WithContext { self =>

--- a/cli/src/main/scala/laserdisc/cli/CLI.scala
+++ b/cli/src/main/scala/laserdisc/cli/CLI.scala
@@ -1,5 +1,4 @@
-package laserdisc
-package fs2
+package laserdisc.cli
 
 import java.nio.channels.AsynchronousChannelGroup.withThreadPool
 import java.util.concurrent.Executors._
@@ -13,6 +12,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.fromExecutorService
 import scala.reflect.runtime.universe
 import scala.tools.reflect.ToolBox
+
+import laserdisc._
+import laserdisc.fs2._
 
 object CLI extends IOApp.WithContext { self =>
 
@@ -76,7 +78,7 @@ object CLI extends IOApp.WithContext { self =>
     case _ => IO(println("please supply host and port (space separated)")).as(ExitCode.Error)
   }
 
-  private[fs2] final object impl {
+  private[cli] final object impl {
     private[this] val tb = universe.runtimeMirror(self.getClass.getClassLoader).mkToolBox()
 
     def mkStream(host: Host, port: Port): Stream[IO, ExitCode] =


### PR DESCRIPTION
This promotes the CLI object to its own module dependent on the fs2
module and aggregated into the root project.