### PR TITLE
Removal of <: Singleton and usages

### DIFF
--- a/core/src/main/boilerplate/HashPExtra.scala.template
+++ b/core/src/main/boilerplate/HashPExtra.scala.template
@@ -23,10 +23,7 @@ trait HashPExtra { this: HashP =>
   ]
 
   //HMSET
-  [..21#final def hmset[[#A1 <: XString, B1: Show#]](key: Key, [#field1: SingletonKey[A1], value1: B1#]): Protocol.Aux[OK] = {
-    [#val tagged1 = tag[A1](Symbol(field1.value))#
-    ]
-    hmset(key, [#labelled.field[tagged1.type](value1)# :: ] :: HNil)
-  }#
+  [..21#final def hmset[[#A1: Show#]](key: Key, [#field1: Key, value1: A1#]): Protocol.Aux[OK] =
+    hmset(key, [#(field1, value1)# :: ] :: HNil)#
   ]
 }

--- a/core/src/main/boilerplate/StringPExtra.scala.template
+++ b/core/src/main/boilerplate/StringPExtra.scala.template
@@ -19,18 +19,12 @@ trait StringPExtra { this: StringP =>
   ]
 
   //MSET
-  [#final def mset[[#A1 <: XString, B1: Show#]]([#key1: SingletonKey[A1], value1: B1#]): Protocol.Aux[OK] = {
-    [#val tagged1 = tag[A1](Symbol(key1.value))#
-    ]
-    mset([#labelled.field[tagged1.type](value1)# :: ] :: HNil)
-  }#
+  [#final def mset[[#A1: Show#]]([#key1: Key, value1: A1#]): Protocol.Aux[OK] =
+    mset([#(key1, value1)# :: ] :: HNil)#
   ]
 
   //MSETNX
-  [#final def msetnx[[#A1 <: XString, B1: Show#]]([#key1: SingletonKey[A1], value1: B1#]): Protocol.Aux[Boolean] = {
-    [#val tagged1 = tag[A1](Symbol(key1.value))#
-    ]
-    msetnx([#labelled.field[tagged1.type](value1)# :: ] :: HNil)
-  }#
+  [#final def msetnx[[#A1: Show#]]([#key1: Key, value1: A1#]): Protocol.Aux[Boolean] =
+    msetnx([#(key1, value1)# :: ] :: HNil)#
   ]
 }

--- a/core/src/main/scala/laserdisc/package.scala
+++ b/core/src/main/scala/laserdisc/package.scala
@@ -7,7 +7,6 @@ import eu.timepit.refined.boolean.{And, Not, Or, True}
 import eu.timepit.refined.char.Whitespace
 import eu.timepit.refined.collection.{Forall, MinSize, NonEmpty}
 import eu.timepit.refined.generic.Equal
-import eu.timepit.refined.macros.RefineMacro
 import eu.timepit.refined.numeric.Interval.{Closed => ClosedInterval}
 import eu.timepit.refined.string.{IPv4, MatchesRegex}
 import eu.timepit.refined.types.net.PrivateNetworks._
@@ -36,7 +35,6 @@ package object laserdisc {
   final val Show     = protocol.Show
 
   final type Maybe[A] = Throwable | A
-  final type XString  = String with Singleton
 
   private[this] final type Loopback = IPv4 And Equal[W.`"127.0.0.1"`.T]
   private[this] final type RFC1123HostName = MatchesRegex[
@@ -77,7 +75,6 @@ package object laserdisc {
   final type OneOrMore[A]               = List[A] Refined NonEmpty
   final type OneOrMoreKeys              = OneOrMore[Key]
   final type RangeOffset                = Int Refined ClosedInterval[_0, W.`536870911`.T]
-  final type SingletonKey[A <: XString] = A Refined NonEmpty
   final type StringLength               = Long Refined ClosedInterval[_0, W.`4294967295L`.T]
   final type TwoOrMoreKeys              = List[Key] Refined MinSize[_2]
   final type TwoOrMoreWeightedKeys      = List[(Key, ValidDouble)] Refined MinSize[_2]
@@ -90,15 +87,6 @@ package object laserdisc {
     def unapply[A](l: List[A]): Option[OneOrMore[A]] = from(l).right.toOption
     def unsafeFrom[A](l: List[A])(implicit rt: RefinedType.AuxT[OneOrMore[A], List[A]]): OneOrMore[A] =
       rt.unsafeRefine(l)
-  }
-  final object SingletonKey {
-    import scala.language.experimental.macros
-
-    def apply[A <: XString](t: A)(
-        implicit ev: Refined[A, NonEmpty] =:= SingletonKey[A],
-        rt: RefType[Refined],
-        v: Validate[A, NonEmpty]
-    ): SingletonKey[A] = macro RefineMacro.implApplyRef[SingletonKey[A], Refined, A, NonEmpty]
   }
 
   final object ConnectionName        extends RefinedTypeOps[ConnectionName, String]

--- a/core/src/main/scala/laserdisc/protocol/HashP.scala
+++ b/core/src/main/scala/laserdisc/protocol/HashP.scala
@@ -41,7 +41,7 @@ trait HashP {
   final def hmset[L <: HList: RESPParamWrite, N <: Nat](key: Key, l: L)(
       implicit ev0: Length.Aux[L, N],
       ev1: N >= _1,
-      ev2: LUBConstraint[L, FieldType[_, _]]
+      ev2: LUBConstraint[L, (Key, _)]
   ): Protocol.Aux[OK] = Protocol("HMSET", key :: l).as[SimpleString, OK]
 
   final def hmset[P <: Product, L <: HList, N <: Nat](key: Key, product: P)(

--- a/core/src/main/scala/laserdisc/protocol/StringP.scala
+++ b/core/src/main/scala/laserdisc/protocol/StringP.scala
@@ -158,7 +158,7 @@ trait StringP {
   final def mset[L <: HList: RESPParamWrite, N <: Nat](l: L)(
       implicit ev0: Length.Aux[L, N],
       ev1: N >= _1,
-      ev2: LUBConstraint[L, FieldType[_, _]]
+      ev2: LUBConstraint[L, (Key, _)]
   ): Protocol.Aux[OK] = Protocol("MSET", l).as[SimpleString, OK]
 
   final def mset[P <: Product, L <: HList, N <: Nat](product: P)(
@@ -175,7 +175,7 @@ trait StringP {
   final def msetnx[L <: HList: RESPParamWrite, N <: Nat](l: L)(
       implicit ev0: Length.Aux[L, N],
       ev1: N >= _1,
-      ev2: LUBConstraint[L, FieldType[_, _]]
+      ev2: LUBConstraint[L, (Key, _)]
   ): Protocol.Aux[Boolean] = Protocol("MSETNX", l).as[Integer, Boolean]
 
   final def msetnx[P <: Product, L <: HList, N <: Nat](product: P)(


### PR DESCRIPTION
`mset` and `hmset` were broken due to the presence of `type XString = String <: Singleton` and its attempted usage via `type SingletonKey[A <: XString] = A Refined NonEmpty`