### PR TITLE
remove scala-java-time, not needed since circe 0.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ val V = new {
   val `log-effect-fs2`    = "0.10.1"
   val parallelCollections = "0.2.0"
   val refined             = "0.9.10"
-  val `scala-java-time`   = "2.0.0-RC3"
   val scalacheck          = "1.14.1"
   val scalatest           = "3.0.8"
   val `scodec-bits`       = "1.1.12"
@@ -33,11 +32,10 @@ val `scodec-core`    = Def.setting("org.scodec"    %%% "scodec-core"    % V.`sco
 val `scodec-stream`  = Def.setting("org.scodec"    %%% "scodec-stream"  % V.`scodec-stream`)
 val shapeless        = Def.setting("com.chuusai"   %%% "shapeless"      % V.shapeless)
 
-val `circe-generic`      = Def.setting("io.circe"          %%% "circe-generic"      % V.circe             % Test)
-val `refined-scalacheck` = Def.setting("eu.timepit"        %%% "refined-scalacheck" % V.refined           % Test)
-val scalacheck           = Def.setting("org.scalacheck"    %%% "scalacheck"         % V.scalacheck        % Test)
-val scalatest            = Def.setting("org.scalatest"     %%% "scalatest"          % V.scalatest         % Test)
-val scalaJavaTime        = Def.setting("io.github.cquiroz" %%% "scala-java-time"    % V.`scala-java-time` % Test)
+val `circe-generic`      = Def.setting("io.circe"       %%% "circe-generic"      % V.circe      % Test)
+val `refined-scalacheck` = Def.setting("eu.timepit"     %%% "refined-scalacheck" % V.refined    % Test)
+val scalacheck           = Def.setting("org.scalacheck" %%% "scalacheck"         % V.scalacheck % Test)
+val scalatest            = Def.setting("org.scalatest"  %%% "scalatest"          % V.scalatest  % Test)
 
 val parallelCollectionsInTest = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value) match {
@@ -87,8 +85,7 @@ val circeDeps = Def.Initialize.join {
     `circe-parser`,
     `circe-generic`,
     scalacheck,
-    scalatest,
-    scalaJavaTime
+    scalatest
   )
 }
 


### PR DESCRIPTION
See https://github.com/circe/circe/pull/1249