### PR TITLE
Resp frame bench opt

### DIFF
--- a/benchmarks/core/src/main/scala/laserdisc/protocol/RESPFrameBench.scala
+++ b/benchmarks/core/src/main/scala/laserdisc/protocol/RESPFrameBench.scala
@@ -1,0 +1,156 @@
+package laserdisc
+package protocol
+
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+import scodec.bits.BitVector
+import eu.timepit.refined.types.string.NonEmptyString
+
+import java.nio.ByteBuffer
+
+@State(Scope.Benchmark)
+class RESPFrameBench {
+
+  val shortStr = " Short string repeated string repeated string repeated"
+  val mediumStr = "Medium size string repeated medium size string repeated medium size string repeated medium size string repeated medium size string repeated medium size string repeated medium size string repeated medium size string repeated medium size string"
+  val longStr = "Very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very  very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long string"
+
+  val mixedNoArrList = List(
+    StrEncoded(mediumStr),
+    NullArrEncoded(),
+    NumEncoded(21),
+    StrEncoded(longStr),
+    StrEncoded("OK"),
+    BulkEncoded(NonEmptyString.unsafeFrom(longStr)),
+    NumEncoded(150),
+    StrEncoded(""),
+    ErrEncoded(NonEmptyString.unsafeFrom(mediumStr)),
+    BulkEncoded(NonEmptyString.unsafeFrom(shortStr)),
+    NullBulkEncoded(),
+    StrEncoded(longStr),
+    StrEncoded("OK"),
+    EmptyArrEncoded(),
+    StrEncoded(longStr),
+    BulkEncoded(NonEmptyString.unsafeFrom(mediumStr)),
+    NumEncoded(200),
+    NullBulkEncoded(),
+    EmptyBulkEncoded(),
+    StrEncoded(""),
+    BulkEncoded(NonEmptyString.unsafeFrom(longStr)),
+    NumEncoded(Long.MaxValue),
+    StrEncoded(shortStr),
+    NumEncoded(25),
+    BulkEncoded(NonEmptyString.unsafeFrom("PONG")),
+    EmptyArrEncoded(),
+    StrEncoded(longStr),
+    NullArrEncoded(),
+    ErrEncoded(NonEmptyString.unsafeFrom(shortStr)),
+    EmptyBulkEncoded(),
+    StrEncoded("PONG"),
+    NullArrEncoded()
+  )
+
+  val arrOneLevelList = List(
+    NullArrEncoded(),
+    NumEncoded(21),
+    ArrEncoded(mixedNoArrList),
+    StrEncoded("OK"),
+    StrEncoded(""),
+    NumEncoded(Long.MaxValue),
+    StrEncoded(shortStr),
+    StrEncoded("PONG")
+  )
+
+  val arrTwoLevelsList = List(
+    NullArrEncoded(),
+    NumEncoded(21),
+    ArrEncoded(mixedNoArrList),
+    StrEncoded("OK"),
+    StrEncoded(""),
+    ArrEncoded(arrOneLevelList),
+    NumEncoded(Long.MaxValue),
+    StrEncoded(shortStr),
+    StrEncoded("PONG")
+  )
+
+  val arrThreeLevelsList = List(
+    NullArrEncoded(),
+    NumEncoded(21),
+    ArrEncoded(mixedNoArrList),
+    StrEncoded("OK"),
+    StrEncoded(""),
+    ArrEncoded(arrOneLevelList),
+    NumEncoded(Long.MaxValue),
+    StrEncoded(shortStr),
+    ArrEncoded(arrTwoLevelsList),
+    StrEncoded("PONG")
+  )
+
+  val arrFourLevelsList = List(
+    NullArrEncoded(),
+    ArrEncoded(arrThreeLevelsList),
+    NumEncoded(21),
+    ArrEncoded(mixedNoArrList),
+    StrEncoded("OK"),
+    StrEncoded(""),
+    ArrEncoded(arrOneLevelList),
+    NumEncoded(Long.MaxValue),
+    StrEncoded(shortStr),
+    ArrEncoded(arrTwoLevelsList),
+    StrEncoded("PONG")
+  )
+
+  val arrFiveLevelsList = List(
+    NullArrEncoded(),
+    ArrEncoded(arrThreeLevelsList),
+    NumEncoded(21),
+    ArrEncoded(mixedNoArrList),
+    StrEncoded("OK"),
+    StrEncoded(""),
+    ArrEncoded(arrOneLevelList),
+    NumEncoded(Long.MaxValue),
+    ArrEncoded(arrFourLevelsList),
+    StrEncoded(shortStr),
+    ArrEncoded(arrTwoLevelsList),
+    StrEncoded("PONG")
+  )
+
+  val mixedNoArr = mixedNoArrList.map(_.encoded).mkString.getBytes
+  val arrOneLevel = arrOneLevelList.map(_.encoded).mkString.getBytes
+  val arrFiveLevels = arrFiveLevelsList.map(_.encoded).mkString.getBytes
+
+  val mixedNoArrFull = BitVector(mixedNoArr).toByteBuffer
+  val arrOneLevelFull = BitVector(arrOneLevel).toByteBuffer
+  val arrFiveLevelsFull = BitVector(arrFiveLevels).toByteBuffer
+
+  @Benchmark def frameOfMixedNoArrFull() = EmptyFrame.append(mixedNoArrFull)
+  @Benchmark def frameOfMixedArrOneLevelFull() = EmptyFrame.append(arrOneLevelFull)
+  @Benchmark def frameOfMixedArrFiveLevelsFull() = EmptyFrame.append(arrFiveLevelsFull)
+
+  def groupInChunks(bytes :Array[Byte], chunkSize: Int) =
+    bytes.grouped(chunkSize).map(c => BitVector.apply(c).toByteBuffer)
+
+  def appendChunks(buff: Iterator[ByteBuffer]) =
+    buff.foldLeft[RESPFrame](EmptyFrame) { (acc, n) =>
+      acc.append(n) match {
+        case Right(MoreThanOneFrame(_, reminder)) => IncompleteFrame(reminder, 0)
+        case Right(fs)                            => fs
+        case Left(e)                              => throw e
+      }
+    }
+
+  val mixedNoArrSmallChunkBuffers    = groupInChunks(mixedNoArr, 100)
+  val arrOneLevelSmallChunkBuffers   = groupInChunks(arrOneLevel, 100)
+  val arrFiveLevelsSmallChunkBuffers = groupInChunks(arrFiveLevels, 100)
+
+  @Benchmark def frameOfShortChunkedMixedNoArr()    = appendChunks(mixedNoArrSmallChunkBuffers)
+  @Benchmark def frameOfShortChunkedArrOneLevel()   = appendChunks(arrOneLevelSmallChunkBuffers)
+  @Benchmark def frameOfShortChunkedArrFiveLevels() = appendChunks(arrFiveLevelsSmallChunkBuffers)
+
+  val mixedNoArrBigChunkBuffers    = groupInChunks(mixedNoArr, 1024)
+  val arrOneLevelBigChunkBuffers   = groupInChunks(arrOneLevel, 1024)
+  val arrFiveLevelsBigChunkBuffers = groupInChunks(arrFiveLevels, 1024)
+
+  @Benchmark def frameOfLongChunkedMixedNoArr()    = appendChunks(mixedNoArrBigChunkBuffers)
+  @Benchmark def frameOfLongChunkedArrOneLevel()   = appendChunks(arrOneLevelBigChunkBuffers)
+  @Benchmark def frameOfLongChunkedArrFiveLevels() = appendChunks(arrFiveLevelsBigChunkBuffers)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,7 @@ lazy val fs2 = project
 
 lazy val `core-bench` = project
   .in(file("benchmarks/core"))
-  .dependsOn(core.jvm)
+  .dependsOn(core.jvm % "compile->test;compile->compile")
   .enablePlugins(JmhPlugin)
   .settings(
     name := "laserdisc-core-benchmarks",

--- a/core/.js/src/main/scala/laserdisc/Platform.scala
+++ b/core/.js/src/main/scala/laserdisc/Platform.scala
@@ -3,5 +3,5 @@ package laserdisc
 private[laserdisc] object Platform {
   abstract class LaserDiscRuntimeError(message: String)              extends RuntimeException(message, null)
   abstract class LaserDiscRespProtocolDecodingError(message: String) extends RuntimeException(message, null)
-  abstract class LaserDiscRespFrameError(message: String)            extends RuntimeException(message, null, true, false)
+  abstract class LaserDiscRespFrameError(message: String)            extends RuntimeException(message, null)
 }

--- a/core/.js/src/main/scala/laserdisc/Platform.scala
+++ b/core/.js/src/main/scala/laserdisc/Platform.scala
@@ -3,4 +3,5 @@ package laserdisc
 private[laserdisc] object Platform {
   abstract class LaserDiscRuntimeError(message: String)              extends RuntimeException(message, null)
   abstract class LaserDiscRespProtocolDecodingError(message: String) extends RuntimeException(message, null)
+  abstract class LaserDiscRespFrameError(message: String)            extends RuntimeException(message, null, true, false)
 }

--- a/core/.jvm/src/main/scala/laserdisc/Platform.scala
+++ b/core/.jvm/src/main/scala/laserdisc/Platform.scala
@@ -3,4 +3,5 @@ package laserdisc
 private[laserdisc] object Platform {
   abstract class LaserDiscRuntimeError(message: String)              extends RuntimeException(message, null, true, false)
   abstract class LaserDiscRespProtocolDecodingError(message: String) extends RuntimeException(message, null, true, false)
+  abstract class LaserDiscRespFrameError(message: String)            extends RuntimeException(message, null, true, false)
 }

--- a/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESPFrame.scala
@@ -9,43 +9,43 @@ import scodec.bits.BitVector
 
 import scala.annotation.tailrec
 
-sealed trait RESPFrame extends Product with Serializable with EitherSyntax with BitVectorSyntax {
+private[laserdisc] sealed trait RESPFrame extends Product with Serializable with EitherSyntax with BitVectorSyntax {
   def append(bytes: ByteBuffer): Exception | NonEmptyRESPFrame = nextFrame(BitVector.view(bytes))
   protected final def nextFrame(bits: BitVector): Exception | NonEmptyRESPFrame =
     stateOf(bits)
       .flatMap {
-        case MissingBits(n)              => IncompleteFrame(bits, n).asRight
-        case Incomplete                  => IncompleteFrame(bits, 0L).asRight
-        case Complete                    => CompleteFrame(bits).asRight
-        case CompleteWithRemainder(c, r) => consumeRemainder(MoreThanOneFrame(CompleteFrame(c) :: Nil, r).asRight)
+        case MissingBits(n)              => Right(IncompleteFrame(bits, n))
+        case Incomplete                  => Right(IncompleteFrame(bits, 0L))
+        case Complete                    => Right(CompleteFrame(bits))
+        case CompleteWithRemainder(c, r) => consumeRemainder(Right(MoreThanOneFrame(Vector(CompleteFrame(c)), r)))
       }
-      .leftMap(e => new Exception(s"Err building the frame: $e. Content: ${bits.tailToUtf8}"))
+      .leftMap(e => UnknownBufferState(s"Err building the frame from buffer: $e. Content: ${bits.tailToUtf8}"))
 
   @tailrec private[this] final def consumeRemainder(current: String | MoreThanOneFrame): String | MoreThanOneFrame = current match {
     case Right(s) =>
       stateOf(s.remainder) match {
-        case Left(ee)                           => ee.asLeft
-        case Right(CompleteWithRemainder(c, r)) => consumeRemainder(MoreThanOneFrame(CompleteFrame(c) :: s.invertedComplete, r).asRight)
-        case Right(Complete)                    => MoreThanOneFrame(CompleteFrame(s.remainder) :: s.invertedComplete, BitVector.empty).asRight
-        case _                                  => s.asRight
+        case Left(ee)                           => Left(ee)
+        case Right(CompleteWithRemainder(c, r)) => consumeRemainder(Right(MoreThanOneFrame(s.complete.:+(CompleteFrame(c)), r)))
+        case Right(Complete)                    => Right(MoreThanOneFrame(s.complete.:+(CompleteFrame(s.remainder)), BitVector.empty))
+        case _                                  => Right(s)
       }
     case left => left
   }
 }
 
-case object EmptyFrame                           extends RESPFrame
+private[laserdisc] case object EmptyFrame        extends RESPFrame
 private[protocol] sealed trait NonEmptyRESPFrame extends RESPFrame
 
-final case class CompleteFrame(bits: BitVector) extends NonEmptyRESPFrame
-final case class MoreThanOneFrame(private[protocol] val invertedComplete: List[CompleteFrame], remainder: BitVector)
-    extends NonEmptyRESPFrame {
-  def complete: Vector[CompleteFrame] = invertedComplete.foldRight(Vector.empty[CompleteFrame])((c, v) => v :+ c)
-}
-final case class IncompleteFrame(partial: BitVector, bitsToComplete: Long) extends NonEmptyRESPFrame {
+private[laserdisc] final case class CompleteFrame(bits: BitVector) extends NonEmptyRESPFrame
+private[laserdisc] final case class MoreThanOneFrame(private[laserdisc] val complete: Vector[CompleteFrame], remainder: BitVector)
+    extends NonEmptyRESPFrame
+private[laserdisc] final case class IncompleteFrame(partial: BitVector, bitsToComplete: Long) extends NonEmptyRESPFrame {
   override def append(bytes: ByteBuffer): Exception | NonEmptyRESPFrame = {
     val newBits = BitVector.view(bytes)
     //  Saves some size checks
-    if (bitsToComplete > 0 && bitsToComplete == newBits.size) CompleteFrame(partial ++ newBits).asRight
+    if (bitsToComplete > 0 && bitsToComplete == newBits.size) Right(CompleteFrame(partial ++ newBits))
     else nextFrame(partial ++ newBits)
   }
 }
+
+private[laserdisc] final case class UnknownBufferState(message: String) extends laserdisc.Platform.LaserDiscRespFrameError(message)

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameArrSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameArrSpec.scala
@@ -48,8 +48,10 @@ final class RESPFrameArrSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
+                CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes))
+              ),
               BitVector.empty
             )
           )
@@ -64,8 +66,10 @@ final class RESPFrameArrSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
+                CompleteFrame(BitVector("*2\r\n$8\r\nAnother1\r\n-An error\r\n".getBytes))
+              ),
               BitVector("$17\r\nAnother bulk ".getBytes())
             )
           )
@@ -80,12 +84,14 @@ final class RESPFrameArrSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes))
+              ),
               BitVector.empty
             )
           )
@@ -100,12 +106,14 @@ final class RESPFrameArrSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*-1\r\n".getBytes)) ::
-                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("*3\r\n$16\r\nTest bulk string\r\n:100\r\n+A simple string\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes)),
+                CompleteFrame(BitVector("*-1\r\n".getBytes))
+              ),
               BitVector("*".getBytes())
             )
           )

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameBulkSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameBulkSpec.scala
@@ -39,7 +39,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         EmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(3)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+              Vector.fill(3)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
               BitVector.empty
             )
           )
@@ -53,7 +53,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         EmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(2)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+              Vector.fill(2)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
               BitVector("$16\r\nTest bulk".getBytes())
             )
           )
@@ -67,7 +67,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         EmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(6)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
+              Vector.fill(6)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
               BitVector.empty
             )
           )
@@ -81,7 +81,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         EmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(4)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
+              Vector.fill(4)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
               BitVector("$".getBytes())
             )
           )
@@ -97,10 +97,12 @@ final class RESPFrameBulkSpec extends BaseSpec {
         EmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("$18\r\nTest bulk string 4\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$18\r\nTest bulk string 3\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$18\r\nTest bulk string 2\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$18\r\nTest bulk string 1\r\n".getBytes())) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("$18\r\nTest bulk string 1\r\n".getBytes())),
+                CompleteFrame(BitVector("$18\r\nTest bulk string 2\r\n".getBytes())),
+                CompleteFrame(BitVector("$18\r\nTest bulk string 3\r\n".getBytes())),
+                CompleteFrame(BitVector("$18\r\nTest bulk string 4\r\n".getBytes()))
+              ),
               BitVector("$18\r\nTest bulk".getBytes())
             )
           )
@@ -151,7 +153,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(3)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+              Vector.fill(3)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
               BitVector.empty
             )
           )
@@ -166,7 +168,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(2)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
+              Vector.fill(2)(CompleteFrame(BitVector("$16\r\nTest bulk string\r\n".getBytes()))),
               BitVector("$16\r\nTest bulk".getBytes())
             )
           )
@@ -181,7 +183,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(6)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
+              Vector.fill(6)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
               BitVector.empty
             )
           )
@@ -196,7 +198,7 @@ final class RESPFrameBulkSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              List.fill(4)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
+              Vector.fill(4)(CompleteFrame(BitVector("$-1\r\n".getBytes()))),
               BitVector("$".getBytes())
             )
           )
@@ -213,10 +215,12 @@ final class RESPFrameBulkSpec extends BaseSpec {
         nonEmptyFrame.append(inputVector.toByteBuffer) should be(
           Right(
             MoreThanOneFrame(
-              CompleteFrame(BitVector("$19\r\nTest bulk string 40\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$20\r\nTest bulk string 3 1\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$17\r\nTest bulk string2\r\n".getBytes())) ::
-                CompleteFrame(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())) :: Nil,
+              Vector(
+                CompleteFrame(BitVector("$21\r\nTest bulk string 1 11\r\n".getBytes())),
+                CompleteFrame(BitVector("$17\r\nTest bulk string2\r\n".getBytes())),
+                CompleteFrame(BitVector("$20\r\nTest bulk string 3 1\r\n".getBytes())),
+                CompleteFrame(BitVector("$19\r\nTest bulk string 40\r\n".getBytes()))
+              ),
               BitVector("$18\r\nTest bulk".getBytes())
             )
           )

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameMixedSpec.scala
@@ -97,7 +97,7 @@ private[protocol] trait HighPriorityGenerators extends LowPriorityGenerators {
   private[this] def listProtocol(gen: Gen[ProtocolEncoded]): Gen[List[ProtocolEncoded]] =
     Gen.chooseNum(1, 20) flatMap (Gen.listOfN(_, gen))
 
-  protected final def noArrEncoded(
+  private[this] final def noArrEncoded(
       implicit
       bulk: Gen[BulkEncoded],
       num: Gen[NumEncoded],
@@ -119,10 +119,10 @@ private[protocol] trait HighPriorityGenerators extends LowPriorityGenerators {
       3  -> nullArr
     )
 
-  protected final val noArrArrEncoded: Gen[ArrEncoded] =
+  private[this] final val noArrArrEncoded: Gen[ArrEncoded] =
     listProtocol(noArrEncoded) map ArrEncoded.apply
 
-  private final def oneLevelArrEncoded(arrGen: Gen[ArrEncoded]): Gen[ArrEncoded] =
+  private[this] final def oneLevelArrEncoded(arrGen: Gen[ArrEncoded]): Gen[ArrEncoded] =
     listProtocol(
       Gen.frequency(
         20 -> noArrEncoded,
@@ -130,7 +130,7 @@ private[protocol] trait HighPriorityGenerators extends LowPriorityGenerators {
       )
     ) map ArrEncoded.apply
 
-  protected final def xLevelsNestedArrEncoded(x: Int): Gen[ArrEncoded] = {
+  private[this] final def xLevelsNestedArrEncoded(x: Int): Gen[ArrEncoded] = {
 
     @scala.annotation.tailrec
     def loop(left: Int, soFar: Gen[ArrEncoded]): Gen[ArrEncoded] =
@@ -140,7 +140,7 @@ private[protocol] trait HighPriorityGenerators extends LowPriorityGenerators {
     loop(x, oneLevelArrEncoded(noArrArrEncoded))
   }
 
-  protected final val protocolEncoded: Gen[ProtocolEncoded] =
+  private[this] final val protocolEncoded: Gen[ProtocolEncoded] =
     Gen.frequency(
       50 -> noArrEncoded,
       25 -> oneLevelArrEncoded(noArrArrEncoded),
@@ -148,7 +148,7 @@ private[protocol] trait HighPriorityGenerators extends LowPriorityGenerators {
       10 -> xLevelsNestedArrEncoded(5)
     )
 
-  protected implicit final val oneOrMoreProtocols: Arbitrary[OneOrMore[ProtocolEncoded]] =
+  private[protocol] implicit final val oneOrMoreProtocols: Arbitrary[OneOrMore[ProtocolEncoded]] =
     Arbitrary(oneOrMoreProtocol(protocolEncoded))
 }
 

--- a/core/src/test/scala/laserdisc/protocol/RESPFrameNumSpec.scala
+++ b/core/src/test/scala/laserdisc/protocol/RESPFrameNumSpec.scala
@@ -1,0 +1,25 @@
+package laserdisc
+package protocol
+
+import scodec.bits.BitVector
+
+final class RESPFrameNumSpec extends BaseSpec {
+  "An empty Bulk Frame" when {
+
+    "appending a bit vector with a number split in two chunks" should {
+      "produce MoreThanOneFrame with a follow up partial bulk string" in {
+        val incompleteFirstInput = BitVector(":2".getBytes)
+        val secondInput          = BitVector(s"1${CRLF}$$18${CRLF}Test bulk".getBytes)
+
+        EmptyFrame.append(incompleteFirstInput.toByteBuffer).flatMap(_.append(secondInput.toByteBuffer)) should be(
+          Right(
+            MoreThanOneFrame(
+              Vector(CompleteFrame(BitVector(s":21${CRLF}".getBytes))),
+              BitVector(s"$$18${CRLF}Test bulk".getBytes)
+            )
+          )
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
The change is mainly in `RESPFrame`. It simplifies the frame structure a bit and doesn't change the run time that much (see below), so I would say it's a bit better. The thing that surprised me a bit is the impact on the long buffer chunks benchmarks, especially for the nested arrays. I will keep looking into it a bit, but I guess it's not an issue for the PR.  
```
Benchmark                                                 Mode  Cnt          Score         Error  Units
RESPFrameBench.frameOfMixedNoArrFull            (master) thrpt   20      14111.611 ±     290.981  ops/s
RESPFrameBench.frameOfMixedNoArrFull            (branch) thrpt   20      14142.744 ±      57.385  ops/s

RESPFrameBench.frameOfMixedArrOneLevelFull      (master) thrpt   20      12993.851 ±     181.844  ops/s
RESPFrameBench.frameOfMixedArrOneLevelFull      (branch) thrpt   20      13236.705 ±     114.179  ops/s

RESPFrameBench.frameOfMixedArrFiveLevelsFull    (master) thrpt   20        790.228 ±       4.986  ops/s
RESPFrameBench.frameOfMixedArrFiveLevelsFull    (branch) thrpt   20        753.304 ±       2.789  ops/s

------

RESPFrameBench.frameOfShortChunkedMixedNoArr    (master) thrpt   20  296874486.067 ± 4533266.397  ops/s
RESPFrameBench.frameOfShortChunkedMixedNoArr    (branch) thrpt   20  285606051.559 ± 6590259.973  ops/s

RESPFrameBench.frameOfShortChunkedArrOneLevel   (master) thrpt   20  240354473.654 ± 4265439.208  ops/s
RESPFrameBench.frameOfShortChunkedArrOneLevel   (branch) thrpt   20  245804458.021 ± 2031619.029  ops/s

RESPFrameBench.frameOfShortChunkedArrFiveLevels (master) thrpt   20  255654787.394 ± 4162926.432  ops/s
RESPFrameBench.frameOfShortChunkedArrFiveLevels (branch) thrpt   20  259908716.378 ± 3694391.720  ops/s

------

RESPFrameBench.frameOfLongChunkedMixedNoArr     (master) thrpt   20  297325045.238 ± 1447875.624  ops/s
RESPFrameBench.frameOfLongChunkedMixedNoArr     (branch) thrpt   20  304247653.532 ± 1136852.946  ops/s ~ +2.32%

RESPFrameBench.frameOfLongChunkedArrOneLevel    (master) thrpt   20  296578953.829 ± 1196015.167  ops/s
RESPFrameBench.frameOfLongChunkedArrOneLevel    (branch) thrpt   20  304013214.470 ± 1649871.654  ops/s ~ +2.50%

RESPFrameBench.frameOfLongChunkedArrFiveLevels  (master) thrpt   20  159460593.233 ±  927371.081  ops/s
RESPFrameBench.frameOfLongChunkedArrFiveLevels  (branch) thrpt   20  211525613.872 ± 2970233.094  ops/s ~ +32.65%
```