### PR TITLE
Issue 46: Add laws verification for Read

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,9 @@ val `scala 2.12` = "2.12.10"
 val `scala 2.13` = "2.13.1"
 
 val V = new {
+  val cats                   = "2.1.0"
+  val `cats-discipline`      = "1.0.0"
+  val `discipline-scalatest` = "1.0.0-RC1"
   val circe                  = "0.12.3"
   val fs2                    = "2.1.0"
   val `kind-projector`       = "0.11.0"
@@ -20,6 +23,8 @@ val V = new {
   val shapeless              = "2.3.3"
 }
 
+val `cats-core`      = Def.setting("org.typelevel" %% "cats-core"       % V.cats)
+val `cats-laws`      = Def.setting("org.typelevel" %% "cats-laws"       % V.cats)
 val `circe-core`     = Def.setting("io.circe"      %%% "circe-core"     % V.circe)
 val `circe-parser`   = Def.setting("io.circe"      %%% "circe-parser"   % V.circe)
 val `fs2-core`       = Def.setting("co.fs2"        %%% "fs2-core"       % V.fs2)
@@ -32,10 +37,13 @@ val `scodec-core`    = Def.setting("org.scodec"    %%% "scodec-core"    % V.`sco
 val `scodec-stream`  = Def.setting("org.scodec"    %%% "scodec-stream"  % V.`scodec-stream`)
 val shapeless        = Def.setting("com.chuusai"   %%% "shapeless"      % V.shapeless)
 
-val `circe-generic`      = Def.setting("io.circe"       %%% "circe-generic"      % V.circe      % Test)
-val `refined-scalacheck` = Def.setting("eu.timepit"     %%% "refined-scalacheck" % V.refined    % Test)
-val scalacheck           = Def.setting("org.scalacheck" %%% "scalacheck"         % V.scalacheck % Test)
-val scalatest            = Def.setting("org.scalatest"  %%% "scalatest"          % V.scalatest  % Test)
+val `cats-discipline`      = Def.setting("org.typelevel"  %% "discipline-core"      % V.`cats-discipline`      % Test)
+val `discipline-scalatest` = Def.setting("org.typelevel"  %% "discipline-scalatest" % V.`discipline-scalatest` % Test)
+val `circe-generic`        = Def.setting("io.circe"       %%% "circe-generic"       % V.circe                  % Test)
+val `refined-scalacheck`   = Def.setting("eu.timepit"     %%% "refined-scalacheck"  % V.refined                % Test)
+val scalacheck             = Def.setting("org.scalacheck" %%% "scalacheck"          % V.scalacheck             % Test)
+val scalatest              = Def.setting("org.scalatest"  %%% "scalatest"           % V.scalatest              % Test)
+
 val `scala-parallel-collections` = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, major)) if major >= 13 =>
@@ -59,6 +67,15 @@ val coreDeps = Def.Initialize.join {
     `refined-scalacheck`,
     scalacheck,
     scalatest
+  )
+}
+
+val coreLawsDeps = Def.Initialize.join {
+  Seq(
+    `cats-core`,
+    `cats-laws`,
+    `cats-discipline`,
+    `discipline-scalatest`
   )
 }
 
@@ -268,6 +285,16 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .jsConfigure(_.enablePlugins(BoilerplatePlugin))
   .jvmConfigure(_.enablePlugins(BoilerplatePlugin))
 
+lazy val `core-laws` = project
+  .in(file("core-laws"))
+  .dependsOn(core.jvm)
+  .settings(commonSettings ++ testSettings)
+  .settings(
+    name := "laserdisc-core-laws",
+    libraryDependencies ++= coreDeps.value ++ coreLawsDeps.value,
+    publishArtifact := false
+  )
+
 lazy val fs2 = project
   .in(file("fs2"))
   .dependsOn(core.jvm)
@@ -311,7 +338,7 @@ lazy val circe = crossProject(JSPlatform, JVMPlatform)
 
 lazy val laserdisc = project
   .in(file("."))
-  .aggregate(core.jvm, core.js, fs2, cli, circe.jvm, circe.js)
+  .aggregate(core.jvm, core.js, `core-laws`, fs2, cli, circe.jvm, circe.js)
   .settings(publishSettings)
   .settings(
     publishArtifact := false,

--- a/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
+++ b/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
@@ -1,0 +1,29 @@
+package laserdisc
+package protocol
+
+import cats.{Contravariant, Functor, Monad}
+
+import scala.util.{Left, Right}
+
+private[protocol] object ReadInstances {
+  implicit def readFunctor[X]: Functor[X ==> *] =
+    new Functor[X ==> *] {
+      override def map[A, B](fa: X ==> A)(f: A => B): X ==> B = fa.map(f)
+    }
+
+  implicit def readContravariant[X]: Contravariant[* ==> X] =
+    new Contravariant[* ==> X] {
+      override def contramap[A, B](fa: A ==> X)(f: B => A): B ==> X = fa.contramap(f)
+    }
+
+  implicit def readMonad[X]: Monad[X ==> *] =
+    new Monad[X ==> *] {
+      override def pure[A](x: A): X ==> A                               = Read.const(x)
+      override def flatMap[A, B](fa: X ==> A)(f: A => X ==> B): X ==> B = fa.flatMap(f)
+      override def tailRecM[A, B](a: A)(f: A => X ==> Either[A, B]): X ==> B =
+        flatMap(f(a)) {
+          case Left(a)  => tailRecM(a)(f)
+          case Right(b) => pure(b)
+        }
+    }
+}

--- a/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
+++ b/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
@@ -1,7 +1,7 @@
 package laserdisc
 package protocol
 
-import cats.{Contravariant, Functor, Monad}
+import cats.{Contravariant, Functor, Invariant, Monad}
 
 import scala.util.{Left, Right}
 
@@ -14,6 +14,16 @@ private[protocol] object ReadInstances {
   implicit def readContravariant[X]: Contravariant[* ==> X] =
     new Contravariant[* ==> X] {
       override def contramap[A, B](fa: A ==> X)(f: B => A): B ==> X = fa.contramap(f)
+    }
+
+  implicit def readInvariantFirst[X]: Invariant[* ==> X] =
+    new Invariant[* ==> X] {
+      override def imap[A, B](fa: A ==> X)(f: A => B)(g: B => A): B ==> X = fa.contramap(g)
+    }
+
+  implicit def readInvariantSecond[X]: Invariant[X ==> *] =
+    new Invariant[X ==> *] {
+      override def imap[A, B](fa: X ==> A)(f: A => B)(g: B => A): X ==> B = fa.map(f)
     }
 
   implicit def readMonad[X]: Monad[X ==> *] =

--- a/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
+++ b/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
@@ -4,8 +4,8 @@ package protocol
 import cats.instances.int._
 import cats.instances.long._
 import cats.instances.string._
-import cats.laws.discipline.{ContravariantTests, MonadTests, SerializableTests}
-import cats.{Contravariant, Eq, Monad}
+import cats.laws.discipline.{ContravariantTests, InvariantTests, MonadTests, SerializableTests}
+import cats.{Contravariant, Eq, Invariant, Monad}
 import org.scalacheck.Gen.chooseNum
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -27,8 +27,14 @@ final class ReadLawsCheck
   checkAll("Read[Num, *]", MonadTests[Read[Num, *]].stackUnsafeMonad[Long, String, Long])
   checkAll("Monad[Read[Num, *]]", SerializableTests.serializable(Monad[Read[Num, *]]))
 
-  checkAll("Read[*, Int]", ContravariantTests[Read[*, Long]].contravariant[Str, Num, Str])
-  checkAll("Contravariant[Read[*, Int]]", SerializableTests.serializable(Contravariant[Read[*, Long]]))
+  checkAll("Read[*, Long]", ContravariantTests[Read[*, Long]].contravariant[Str, Num, Str])
+  checkAll("Contravariant[Read[*, Long]]", SerializableTests.serializable(Contravariant[Read[*, Long]]))
+
+  checkAll("Read[*, Int]", InvariantTests[Read[*, Long]].invariant[Str, Num, Str])
+  checkAll("Invariant[Read[*, Long]]", SerializableTests.serializable(Invariant[Read[*, Long]]))
+
+  checkAll("Read[Num, *]", InvariantTests[Read[Num, *]].invariant[Long, String, Long])
+  checkAll("Invariant[Read[Num, *]]", SerializableTests.serializable(Invariant[Read[Num, *]]))
 }
 
 private[protocol] sealed trait Implicits {

--- a/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
+++ b/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
@@ -1,0 +1,72 @@
+package laserdisc
+package protocol
+
+import cats.instances.int._
+import cats.instances.long._
+import cats.laws.discipline.{ContravariantTests, MonadTests, SerializableTests}
+import cats.{Contravariant, Eq, Monad}
+import org.scalacheck.Gen.chooseNum
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.Configuration
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.typelevel.discipline.scalatest.Discipline
+
+final class ReadLawsCheck
+    extends AnyFunSuiteLike
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks
+    with Discipline
+    with Configuration
+    with Implicits {
+
+  import ReadInstances._
+
+  checkAll("Read[Num, *]", MonadTests[Read[Num, *]].stackUnsafeMonad[Long, Long, Long])
+  checkAll("Monad[Read[Num, *]]", SerializableTests.serializable(Monad[Read[Num, *]]))
+
+  checkAll("Read[*, Int]", ContravariantTests[Read[*, Long]].contravariant[Num, Num, Num])
+  checkAll("Contravariant[Read[*, Int]]", SerializableTests.serializable(Contravariant[Read[*, Long]]))
+}
+
+private[protocol] sealed trait Implicits {
+  implicit val genNum: Gen[Num] = chooseNum(0L, Long.MaxValue) map Num.apply
+
+  implicit def arbNum(implicit ev: Gen[Num]): Arbitrary[Num] = Arbitrary(ev)
+
+  implicit val cogenNum: Cogen[Num] = Cogen(_.value)
+
+  implicit def arbPair(implicit ev: Arbitrary[Long]): Arbitrary[(Num, Long)] =
+    Arbitrary(ev.arbitrary map (l => Num(l) -> l))
+
+  implicit def arbPairFun(implicit ev: Arbitrary[Long]): Arbitrary[(Num, Long => Long)] =
+    Arbitrary(ev.arbitrary map (l => Num(l) -> (_ => l)))
+
+  implicit def arbRead(implicit ev: Arbitrary[Long]): Arbitrary[Read[Num, Long]] =
+    Arbitrary(ev.arbitrary map Read.const)
+
+  implicit def arbReadFun(implicit ev: Arbitrary[Long]): Arbitrary[Read[Num, Long => Long]] =
+    Arbitrary(ev.arbitrary map (l => Read.const(_ => l)))
+
+  implicit def eqTup[A, B](implicit eb: Eq[B]): Eq[(B, B, B)] =
+    new Eq[(B, B, B)] {
+      override def eqv(x: (B, B, B), y: (B, B, B)): Boolean =
+        (x, y) match {
+          case ((x1, x2, x3), (y1, y2, y3)) => eb.eqv(x1, y1) && eb.eqv(x2, y2) && eb.eqv(x3, y3)
+          case _                            => false
+        }
+    }
+
+  implicit def eqRead[A, B](implicit ga: Gen[A], eb: Eq[B]): Eq[Read[A, B]] =
+    new Eq[Read[A, B]] {
+      override def eqv(x: A ==> B, y: A ==> B): Boolean = {
+        val anA = ga.sample.get
+        (x.read(anA), y.read(anA)) match {
+          case (Right(b1), Right(b2)) => eb.eqv(b1, b2)
+          case (Left(e1), Left(e2))   => e1.message == e2.message
+          case _                      => false
+        }
+      }
+    }
+}

--- a/core/src/main/scala/laserdisc/protocol/Read.scala
+++ b/core/src/main/scala/laserdisc/protocol/Read.scala
@@ -24,9 +24,9 @@ Note 2: make sure to inspect the combinators as you may be able to leverage some
 
   final def map[C](f: B => C): Read[A, C] = Read.instance(read(_).map(f))
 
-  final def flatMap[C](f: B => Read[A, C]): Read[A, C] = Read.instance(a => read(a).flatMap(f(_).read(a)))
-
   final def contramap[C](f: C => A): Read[C, B] = Read.instance(read _ compose f)
+
+  final def flatMap[C](f: B => Read[A, C]): Read[A, C] = Read.instance(a => read(a).flatMap(f(_).read(a)))
 
   private[this] final val _extract: Any => Read.Extract[Any] = new Read.Extract[Any](_)
   final def unapply(a: A): Read.Extract[RESPDecErr | B] =
@@ -44,6 +44,8 @@ object Read extends ReadInstances0 {
   @inline final def instance[A, B](f: A => RESPDecErr | B): Read[A, B] = (a: A) => f(a)
 
   @inline final def infallible[A, B](f: A => B): Read[A, B] = (a: A) => Right(f(a))
+
+  @inline final def const[A, B](b: B): Read[A, B] = Read.infallible(_ => b)
 
   @inline final def instancePF[A, B](expectation: String)(pf: PartialFunction[A, B]): Read[A, B] =
     a => if (pf.isDefinedAt(a)) Right(pf(a)) else Left(RESPDecErr(s"Read Error: expected $expectation but was $a"))


### PR DESCRIPTION
This is a first attempt at https://github.com/laserdisc-io/laserdisc/issues/46 . A couple of notes. The most important, I couldn't find a way to make our `Read` `flatMap` or the instance `tailRecM` stack safe so for now I'm checking the `stackUnsafeMonad` laws. Also the `Eq` definition I used for `Read` is based on a single sample. I might add some other attempts.