### PR TITLE
Removed redundant checks

### DIFF
--- a/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
+++ b/core-laws/src/main/scala/laserdisc/protocol/ReadInstances.scala
@@ -1,7 +1,7 @@
 package laserdisc
 package protocol
 
-import cats.{Contravariant, Functor, Invariant, Monad}
+import cats.{Contravariant, Functor, Monad}
 
 import scala.util.{Left, Right}
 
@@ -14,16 +14,6 @@ private[protocol] object ReadInstances {
   implicit def readContravariant[X]: Contravariant[* ==> X] =
     new Contravariant[* ==> X] {
       override def contramap[A, B](fa: A ==> X)(f: B => A): B ==> X = fa.contramap(f)
-    }
-
-  implicit def readInvariantFirst[X]: Invariant[* ==> X] =
-    new Invariant[* ==> X] {
-      override def imap[A, B](fa: A ==> X)(f: A => B)(g: B => A): B ==> X = fa.contramap(g)
-    }
-
-  implicit def readInvariantSecond[X]: Invariant[X ==> *] =
-    new Invariant[X ==> *] {
-      override def imap[A, B](fa: X ==> A)(f: A => B)(g: B => A): X ==> B = fa.map(f)
     }
 
   implicit def readMonad[X]: Monad[X ==> *] =

--- a/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
+++ b/core-laws/src/test/scala/laserdisc/protocol/ReadLawsCheck.scala
@@ -4,8 +4,8 @@ package protocol
 import cats.instances.int._
 import cats.instances.long._
 import cats.instances.string._
-import cats.laws.discipline.{ContravariantTests, InvariantTests, MonadTests, SerializableTests}
-import cats.{Contravariant, Eq, Invariant, Monad}
+import cats.laws.discipline.{ContravariantTests, MonadTests, SerializableTests}
+import cats.{Contravariant, Eq, Monad}
 import org.scalacheck.Gen.chooseNum
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -29,12 +29,6 @@ final class ReadLawsCheck
 
   checkAll("Read[*, Long]", ContravariantTests[Read[*, Long]].contravariant[Str, Num, Str])
   checkAll("Contravariant[Read[*, Long]]", SerializableTests.serializable(Contravariant[Read[*, Long]]))
-
-  checkAll("Read[*, Int]", InvariantTests[Read[*, Long]].invariant[Str, Num, Str])
-  checkAll("Invariant[Read[*, Long]]", SerializableTests.serializable(Invariant[Read[*, Long]]))
-
-  checkAll("Read[Num, *]", InvariantTests[Read[Num, *]].invariant[Long, String, Long])
-  checkAll("Invariant[Read[Num, *]]", SerializableTests.serializable(Invariant[Read[Num, *]]))
 }
 
 private[protocol] sealed trait Implicits {


### PR DESCRIPTION
Both those invariants are implemented by Monad and Contravariant and are checked by their laws checks. They are not needed.