### PR TITLE
Minor help to inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import log.effect.fs2.SyncLogWriter
 object Main extends IOApp {
 
   def redisTest(implicit log: LogWriter[IO]): IO[Unit] =
-    RedisClient.toNode[IO]("localhost", 6379).use { client =>
+    RedisClient.toNode("localhost", 6379).use { client =>
       client.send(
         set("a", 23),
         set("b", 55),

--- a/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
@@ -18,7 +18,7 @@ object RedisClient {
     * Creates a redis client that will handle the blocking network
     * connection's operations on a cached thread pool.
     */
-  @inline final def apply[F[_]: Concurrent: ContextShift: Timer: LogWriter](
+  @inline final def apply[F[_]: LogWriter: Concurrent: ContextShift: Timer](
       addresses: Set[RedisAddress],
       writeTimeout: Option[FiniteDuration] = Some(10.seconds),
       readMaxBytes: Int = 256 * 1024
@@ -30,7 +30,7 @@ object RedisClient {
     * that will handle the blocking network connection's
     * operations on a cached thread pool.
     */
-  @inline final def toNode[F[_]: Concurrent: ContextShift: Timer: LogWriter](
+  @inline final def toNode[F[_]: LogWriter: Concurrent: ContextShift: Timer](
       host: Host,
       port: Port,
       writeTimeout: Option[FiniteDuration] = Some(10.seconds),
@@ -43,7 +43,7 @@ object RedisClient {
     * that will handle the blocking network connection's
     * operations on a cached thread pool.
     */
-  @inline final def toNodeBlockingOn[F[_]: Concurrent: ContextShift: Timer: LogWriter](
+  @inline final def toNodeBlockingOn[F[_]: LogWriter: Concurrent: ContextShift: Timer](
       blockingPool: Blocker
   )(
       host: Host,
@@ -58,7 +58,7 @@ object RedisClient {
     * thread pool will be used to handle the blocking network
     * connection's operations.
     */
-  @inline final def blockingOn[F[_]: Concurrent: ContextShift: Timer: LogWriter](
+  @inline final def blockingOn[F[_]: LogWriter: Concurrent: ContextShift: Timer](
       blockingPool: Blocker
   )(
       addresses: Set[RedisAddress],

--- a/fs2/src/test/scala/laserdisc/fs2/ReadmeExampleSpec.scala
+++ b/fs2/src/test/scala/laserdisc/fs2/ReadmeExampleSpec.scala
@@ -35,7 +35,7 @@ final class ReadmeExampleSpec extends AnyWordSpecLike with Matchers {
     import log.effect.fs2.SyncLogWriter
 
     def redisTest(implicit log: LogWriter[IO]): IO[Unit] =
-      RedisClient.toNode[IO]("localhost", 6379).use { client =>
+      RedisClient.toNode("localhost", 6379).use { client =>
         client.send(
           set("a", 23),
           set("b", 55),


### PR DESCRIPTION
This makes the main use case (when the `RedisClient` is created in the `IOApp`) a bit more friendly. There is no need for the `[IO]`. It works also when the logger is defined like
```scala
object Main extends IOApp {

  implicit val log: LogWriter[IO] = SyncLogWriter.consoleLog[IO]

  val redisTest: IO[Unit] =
    RedisClient.toNode("localhost", 6379).use { client =>
      client.send(
        set("a", 23),
        set("b", 55),
        get[PosInt]("b"),
        get[PosInt]("a")
      ) >>= {
        case (Right(OK), Right(OK), Right(Some(getOfb)), Right(Some(getOfa))) if getOfb.value == 55 && getOfa.value == 23 =>
          log info "yay!"
        case other =>
          log.error(s"something went terribly wrong $other") >>
            IO.raiseError(new RuntimeException("boom"))
      }
    }

  override final def run(args: List[String]): IO[ExitCode] =
    redisTest.as(ExitCode.Success)
}
```

This compiler never ceases to amaze me.