### PR TITLE
Fix snapshot publish

### DIFF
--- a/core/src/main/scala/laserdisc/protocol/RESP.scala
+++ b/core/src/main/scala/laserdisc/protocol/RESP.scala
@@ -21,7 +21,6 @@ import shapeless.Generic
   * Concrete instances of this trait must be created using this trait's companion
   * object's methods, were [[scodec.Codec]]s for each are also defined
   *
-  * @see [[RESPBuilders]]
   * @see [[RESPCodecs]]
   */
 sealed trait RESP extends AnyRef with Serializable
@@ -93,9 +92,6 @@ case object NullBulk extends GenBulk
 
 /**
   * This is the special case of a non-null RESP [[GenBulk]]
-  *
-  * These can be constructed by using the [[RESPBuilders#bulk]]
-  * method
   *
   * @param value The wrapped bulk string value
   */


### PR DESCRIPTION
This should fix the publication of snapshot versions. Now they are failing with this for 2.13
```
[error] /home/travis/build/laserdisc-io/laserdisc/core/src/main/scala/laserdisc/protocol/RESP.scala:94:1: Could not find any member to link for "RESPBuilders#bulk".
[error] /**
[error] ^
[error] /home/travis/build/laserdisc-io/laserdisc/core/src/main/scala/laserdisc/protocol/RESP.scala:17:1: Could not find any member to link for "RESPBuilders".
[error] /** [[https://redis.io/topics/protocol Redis Protocol Specification]]
[error] ^
[error] /home/travis/build/laserdisc-io/laserdisc/core/src/main/scala/laserdisc/protocol/RESP.scala:94:1: Could not find any member to link for "RESPBuilders#bulk".
[error] /**
[error] ^
[error] /home/travis/build/laserdisc-io/laserdisc/core/src/main/scala/laserdisc/protocol/RESP.scala:17:1: Could not find any member to link for "RESPBuilders".
[error] /** [[https://redis.io/topics/protocol Redis Protocol Specification]]
[error] ^
[error] two errors found
```
like [here](https://travis-ci.org/github/laserdisc-io/laserdisc/jobs/715316937#L427)