### PR TITLE
Minor refactoring

### DIFF
--- a/benchmarks/fs2/src/main/scala/laserdisc/fs2/CatsIoTestRunner.scala
+++ b/benchmarks/fs2/src/main/scala/laserdisc/fs2/CatsIoTestRunner.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.{Executors, TimeUnit}
 import cats.effect.{ContextShift, IO, Timer}
 import cats.syntax.flatMap._
 import laserdisc.auto._
-import laserdisc.fs2.parallel.testcases
+import laserdisc.fs2.parallel.testcases.TestCasesLaserdisc
 import log.effect.fs2.SyncLogWriter.consoleLogUpToLevel
 import log.effect.{LogLevels, LogWriter}
 
@@ -26,7 +26,7 @@ object CatsIoTestRunner {
     val runForMinutes = 2
     val task = timer.clock.monotonic(TimeUnit.MINUTES) >>= { start: Long =>
       RedisClient.to("localhost", 6379).use { cl =>
-        val cases = testcases.TestCasesLaserdisc[IO](cl)
+        val cases = TestCasesLaserdisc[IO](cl)
         def loop(count: Long): IO[Long] =
           cases.case1 >> timer.clock.monotonic(TimeUnit.MINUTES) >>= { current =>
             if (current - start >= runForMinutes) IO.pure(count)

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ val V = new {
   val `scodec-stream`        = "2.0.0"
   val scredis                = "2.3.3"
   val shapeless              = "2.3.3"
-  val zio                    = "1.0.0-RC21"
-  val `zio-interop-cats`     = "2.0.0.0-RC14"
+  val zio                    = "1.0.0"
+  val `zio-interop-cats`     = "2.1.4.0"
 }
 
 val `cats-core`        = Def.setting("org.typelevel" %% "cats-core" % V.cats)

--- a/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
+++ b/fs2/src/main/scala/laserdisc/fs2/RedisClient.scala
@@ -122,9 +122,9 @@ object RedisClient {
 
             def pop: F[Option[Request[F]]] =
               inFlight
-                .modify {
-                  case h +: t => t     -> Some(h)
-                  case other  => other -> None
+                .modify { inFl =>
+                  if (inFl.nonEmpty) inFl.tail -> Some(inFl.head)
+                  else inFl                    -> None
                 }
 
             def serverAvailable(address: RedisAddress): Stream[F, Unit] =


### PR DESCRIPTION
Just refactoring, it doesn't bring anything in the performances.
```
Reference (master)
Benchmark                                               Mode  Cnt      Score     Error  Units
ParallelLoadLaserdiscCatsBench.parallelLoad1           thrpt  200   5291.802 ±  14.365  ops/s
ParallelLoadLaserdiscCatsBench.parallelLoad2           thrpt  200  13374.111 ± 117.475  ops/s
ParallelLoadLaserdiscCatsRespBench.parallelLoad1       thrpt  200   5951.609 ±  56.826  ops/s
ParallelLoadLaserdiscCatsRespBench.parallelLoad2       thrpt  200  10264.231 ±  61.130  ops/s
ParallelLoadLaserdiscCatsBitVectorBench.parallelLoad1  thrpt  200   7296.143 ±  33.001  ops/s
ParallelLoadLaserdiscCatsBitVectorBench.parallelLoad2  thrpt  200  11417.866 ± 120.308  ops/s
ParallelLoadLaserdiscCatsByteBench.parallelLoad1       thrpt  200  48985.944 ± 478.882  ops/s
ParallelLoadLaserdiscCatsByteBench.parallelLoad2       thrpt  200  52861.300 ± 143.582  ops/s
ParallelLoadLaserdiscCatsBaselineBench.parallelLoad1   thrpt  200  49127.852 ± 349.831  ops/s
ParallelLoadLaserdiscCatsBaselineBench.parallelLoad2   thrpt  200  53043.959 ± 145.580  ops/s

This Branch:
Benchmark                                               Mode  Cnt      Score     Error  Units
ParallelLoadLaserdiscCatsBench.parallelLoad1           thrpt  200   5173.993 ±  21.867  ops/s
ParallelLoadLaserdiscCatsBench.parallelLoad2           thrpt  200  13530.416 ±   5.406  ops/s
ParallelLoadLaserdiscCatsRespBench.parallelLoad1       thrpt  200   5892.701 ±  58.980  ops/s
ParallelLoadLaserdiscCatsRespBench.parallelLoad2       thrpt  200  10474.042 ±  73.011  ops/s
ParallelLoadLaserdiscCatsBitVectorBench.parallelLoad1  thrpt  200   7162.177 ±  31.172  ops/s
ParallelLoadLaserdiscCatsBitVectorBench.parallelLoad2  thrpt  200  11343.853 ± 111.668  ops/s
ParallelLoadLaserdiscCatsByteBench.parallelLoad1       thrpt  200  48806.660 ± 368.138  ops/s
ParallelLoadLaserdiscCatsByteBench.parallelLoad2       thrpt  200  52606.223 ± 150.208  ops/s
ParallelLoadLaserdiscCatsBaselineBench.parallelLoad1   thrpt  200  49472.836 ± 165.165  ops/s
ParallelLoadLaserdiscCatsBaselineBench.parallelLoad2   thrpt  200  52775.279 ± 170.368  ops/s
```