### PR TITLE
Update jdk, increase test cases, remove codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -70,7 +70,7 @@ jobs:
           - 2.13.10
         java:
           - adopt@1.11
-          - adopt@1.15
+          - adopt@1.17
         os:
           - ubuntu-20.04
     runs-on: ${{ matrix.os }}
@@ -100,9 +100,7 @@ jobs:
           docker run -p 6379:6379 -d redis:alpine
           docker run -p 6380:6379 -d eqalpha/keydb
       - name: Test (${{ matrix.scala }}, ${{ matrix.java }})
-        run: sbt ++${{ matrix.scala }} fullTest
-      - name: Upload To Codecov
-        uses: codecov/codecov-action@v1.3.2
+        run: SBT_OPTS="-Xms4096M -Xmx4096M -XX:MaxMetaspaceSize=2048M" sbt ++${{ matrix.scala }} fullTest
   publish_212:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     name: Publish Snapshot 2.12
@@ -116,7 +114,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Cache
         uses: actions/cache@v2
         with:
@@ -149,7 +147,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Setup Gpg
         uses: olafurpg/setup-gpg@v3
       - name: Cache
@@ -49,7 +49,7 @@ jobs:
       - name: Install Java And Sbt
         uses: olafurpg/setup-scala@v10
         with:
-          java-version: adopt@1.11
+          java-version: adopt@1.17
       - name: Setup Gpg
         uses: olafurpg/setup-gpg@v3
       - name: Cache

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/laserdisc-io/laserdisc/workflows/CI/badge.svg?branch=master)](https://github.com/laserdisc-io/laserdisc/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush)
 [![Release](https://github.com/laserdisc-io/laserdisc/workflows/Release/badge.svg)](https://github.com/laserdisc-io/laserdisc/actions?query=workflow%3ARelease)
 [![Known Vulnerabilities](https://snyk.io/test/github/laserdisc-io/laserdisc/badge.svg?targetFile=build.sbt)](https://snyk.io/test/github/laserdisc-io/laserdisc?targetFile=build.sbt)
-[![codecov.io](https://codecov.io/github/laserdisc-io/laserdisc/coverage.svg?branch=master)](https://codecov.io/github/laserdisc-io/laserdisc?branch=master)
 [![Join the chat at https://gitter.im/laserdisc-io/laserdisc](https://badges.gitter.im/laserdisc-io/laserdisc.svg)](https://gitter.im/laserdisc-io/laserdisc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)

--- a/core/.jvm/src/test/scala/laserdisc/ScalaCheckSettings.scala
+++ b/core/.jvm/src/test/scala/laserdisc/ScalaCheckSettings.scala
@@ -5,10 +5,10 @@ import munit.ScalaCheckSuite
 private[laserdisc] trait ScalaCheckSettings extends ScalaCheckSuite {
   override val scalaCheckTestParameters =
     super.scalaCheckTestParameters
-      .withMinSuccessfulTests(200)
+      .withMinSuccessfulTests(500)
       .withMaxDiscardRatio(20)
       .disableLegacyShrinking
       .withWorkers(16)
       .withMinSize(0)
-      .withMaxSize(150)
+      .withMaxSize(300)
 }

--- a/fs2/src/test/scala/laserdisc/fs2/LaserdiscFs2Suite.scala
+++ b/fs2/src/test/scala/laserdisc/fs2/LaserdiscFs2Suite.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext.fromExecutor
 
 abstract class LaserdiscFs2Suite(p: Port) extends FunSuite {
   protected val runtime = IORuntime(
-    compute = fromExecutor(Executors.newFixedThreadPool(8)),
+    compute = fromExecutor(Executors.newFixedThreadPool(16)),
     blocking = fromExecutor(Executors.newCachedThreadPool()),
     scheduler = global.scheduler,
     shutdown = global.shutdown,


### PR DESCRIPTION
- moves the jdk version to the two most recent LTS (builds with 17)
- increases the test cases in some scenarios
- removes codecov integration